### PR TITLE
fix: don't use gitref (branch name in case of PR)

### DIFF
--- a/sync/04-toolchain-cicd-binding.yaml
+++ b/sync/04-toolchain-cicd-binding.yaml
@@ -5,8 +5,6 @@ metadata:
   name: toolchain-cicd-sync-binding
 spec:
   params:
-  - name: gitref
-    value: $(body.head_commit.id)
   - name: gitsha
     value: $(body.head_commit.id)
   - name: gitrepositoryurl
@@ -20,8 +18,6 @@ metadata:
   name: toolchain-cicd-dry-run-binding
 spec:
   params:
-  - name: gitref
-    value: $(body.pull_request.head.ref)
   - name: gitsha
     value: $(body.pull_request.head.sha)
   - name: prnumber

--- a/sync/06-trigger-templates.yaml
+++ b/sync/06-trigger-templates.yaml
@@ -5,9 +5,6 @@ metadata:
   name: toolchain-cicd-sync-template
 spec:
   params:
-  - name: gitref
-    description: The git revision
-    default: master
   - name: gitrepositoryurl
     description: The git repository url
   - name: gitsha
@@ -39,7 +36,7 @@ spec:
           type: git
           params:
           - name: revision
-            value: $(params.gitref)
+            value: $(params.gitsha)
           - name: url
             value: $(params.gitrepositoryurl)
 ---
@@ -49,9 +46,6 @@ metadata:
   name: toolchain-cicd-dry-run-template
 spec:
   params:
-  - name: gitref
-    description: The git revision
-    default: master
   - name: gitrepositoryurl
     description: The git repository url
   - name: gitsha
@@ -83,6 +77,6 @@ spec:
           type: git
           params:
           - name: revision
-            value: $(params.gitref)
+            value: $(params.gitsha)
           - name: url
             value: $(params.gitrepositoryurl)


### PR DESCRIPTION
don't use the `body.pull_request.head.ref` as it contains the branch name which doesn't work when PR goes from a forked repo.