### PR TITLE
fix: increase the memory while building tools and sha images

### DIFF
--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -28,6 +28,9 @@ spec:
       mountPath: /var/lib/containers
     securityContext:
       privileged: true
+    resources:
+      limits:
+        memory: 1500Mi
     script: |
       #!/bin/sh
       set -ex
@@ -72,7 +75,7 @@ spec:
     resources:
       limits:
         cpu: 500m
-        memory: 2Gi
+        memory: 2500Mi
     script: |
       #!/bin/sh
       set -ex


### PR DESCRIPTION
the reason is that the builds were sometimes hitting the quota.