### PR TITLE
fix: use pipeline SA in sync

### DIFF
--- a/common/sa.yaml
+++ b/common/sa.yaml
@@ -1,6 +1,14 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: image-pusher
+secrets:
+- name: push-to-quay-secret
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
 secrets:
 - name: push-to-quay-secret

--- a/sync/06-trigger-templates.yaml
+++ b/sync/06-trigger-templates.yaml
@@ -38,7 +38,6 @@ spec:
         value: $(params.gitrepositoryurl)
       - name: quay-namespace
         value: codeready-toolchain
-      serviceAccountName: image-pusher
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate


### PR DESCRIPTION
we need to use the `pipeline` SA in sync pipeline because the `image-pusher` doesn't have permissions to modify the tekton resources. Thus I had to assign the docker credentials to the `pipeline` SA as well so he is able to push the `buildah-short-sha` image to quay