### PR TITLE
feat: add Dockerfile.tools based on buildah and containing opm

### DIFF
--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -8,6 +8,8 @@ ENV USER_UID=1001 \
     LANG=en_US.utf8 \
     OPM_VERSION=v1.12.5
 
+RUN yum install -y make && yum clean all
+
 RUN curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm \
     && chmod +x opm \
     && cp opm /usr/bin/opm \

--- a/Dockerfile.tools
+++ b/Dockerfile.tools
@@ -1,0 +1,15 @@
+FROM quay.io/buildah/stable:v1.11.0
+
+LABEL maintainer "Devtools <devtools@redhat.com>"
+LABEL author "Devtools <devtools@redhat.com>"
+
+ENV USER_UID=1001 \
+    USER_NAME=toolchain-cicd \
+    LANG=en_US.utf8 \
+    OPM_VERSION=v1.12.5
+
+RUN curl -Lo opm https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm \
+    && chmod +x opm \
+    && cp opm /usr/bin/opm \
+    && rm opm \
+    && opm version

--- a/sync/01-apply-resources-task.yaml
+++ b/sync/01-apply-resources-task.yaml
@@ -2,6 +2,53 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
+  name: build-cicd-tools-image
+spec:
+  workspaces:
+  - name: source
+    mountPath: /source
+
+  params:
+  - name: tls-verify
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    default: "true"
+  - name: subdirectory
+    description: Subdirectory inside "source" workspace that contains the repo.
+    default: "toolchain-cicd"
+  - name: dry-run
+    type: string
+    description: If true then run dryrun.
+    default: "false"
+  - name: quay-namespace
+    type: string
+
+  steps:
+  - name: build-and-push-cicd-tools-image
+    image: quay.io/buildah/stable:v1.11.0
+    workingDir: '$(workspaces.source.path)/$(params.subdirectory)/'
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
+    resources:
+      limits:
+        memory: 1500Mi
+    securityContext:
+      privileged: true
+    script: |
+      #!/bin/sh
+      set -ex
+        buildah bud --tls-verify=$(params.tls-verify) --layers -f ./Dockerfile.tools -t  quay.io/$(params.quay-namespace)/cicd-tools:0.1 .
+      if [[ "$(params.dry-run)" != "true" ]]; then
+        buildah push --tls-verify=$(params.tls-verify) quay.io/$(params.quay-namespace)/cicd-tools:0.1 docker://quay.io/$(params.quay-namespace)/cicd-tools:0.1
+      fi
+
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
   name: apply-resources-task
 spec:
   workspaces:

--- a/sync/03-sync-toolchain-cd-pipeline.yaml
+++ b/sync/03-sync-toolchain-cd-pipeline.yaml
@@ -53,6 +53,20 @@ spec:
     runAfter:
     - create-pending-status
 
+  - name: build-cicd-tools-image
+    taskRef:
+      name: build-cicd-tools-image
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: dry-run
+      value: $(params.dry-run)
+    - name: quay-namespace
+      value: $(params.quay-namespace)
+    runAfter:
+    - fetch-repository
+
   - name: apply-common-directory
     taskRef:
       name: apply-resources-task
@@ -143,6 +157,7 @@ spec:
     runAfter:
     - ensure-webhooks
     - apply-toolchain-cd-pipeline
+    - build-cicd-tools-image
     params:
     - name: repo
       value: $(params.repo)


### PR DESCRIPTION
Adds Dockerfile.tools that is built on top of buildah and containing opm binary - this will be used for pushing bundle and index images to quay