### PR TITLE
chore: push new manifests as app and as bundle image

### DIFF
--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -115,7 +115,7 @@ spec:
     type: string
   steps:
 
-  - name: generate-cd-release-manifests
+  - name: generate-cd-release-manifests-and-push-as-app
     securityContext:
       privileged: true
     workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
@@ -123,7 +123,7 @@ spec:
     script: |
       #!/bin/sh
       set -e
-      make push-to-quay-nightly QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
+      make generate-cd-release-manifests QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
       make push-manifests-as-app QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
 
   - name: push-bundle-and-index-image

--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -116,6 +116,9 @@ spec:
   steps:
 
   - name: generate-cd-release-manifests-and-push-as-app
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
     securityContext:
       privileged: true
     workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
@@ -127,6 +130,9 @@ spec:
       make push-manifests-as-app QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
 
   - name: push-bundle-and-index-image
+    volumeMounts:
+    - name: varlibcontainers
+      mountPath: /var/lib/containers
     securityContext:
       privileged: true
     workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
@@ -134,7 +140,7 @@ spec:
     script: |
       #!/bin/sh
       set -e
-      make push-bundle-and-index-image QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp SKIP_TOOLS=true
+      make push-bundle-and-index-image QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp IMAGE_BUILDER=podman
 
   volumes:
   - name: varlibcontainers

--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -111,16 +111,30 @@ spec:
     description: The quay namespace CSV should be pushed to
   - name: tools-image-url
     type: string
+  - name: cicd-tools-image-url
+    type: string
   steps:
 
-  - name: csv
+  - name: generate-cd-release-manifests
     securityContext:
       privileged: true
     workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
     image: $(params.tools-image-url)
-    command: ["make"]
-    args: ["push-to-quay-nightly", "QUAY_NAMESPACE=$(params.quay-namespace)"]
+    script: |
+      #!/bin/sh
+      set -e
+      make push-to-quay-nightly QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
+      make push-manifests-as-app QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
 
+  - name: push-bundle-and-index-image
+    securityContext:
+      privileged: true
+    workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
+    image: $(params.cicd-tools-image-url)
+    script: |
+      #!/bin/sh
+      set -e
+      make push-bundle-and-index-image QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
 
   volumes:
   - name: varlibcontainers

--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -134,7 +134,7 @@ spec:
     script: |
       #!/bin/sh
       set -e
-      make push-bundle-and-index-image QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
+      make push-bundle-and-index-image QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp SKIP_TOOLS=true
 
   volumes:
   - name: varlibcontainers

--- a/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
+++ b/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
@@ -44,6 +44,6 @@ spec:
       - name: binary-image-url
         value: quay.io/$(params.quay-namespace)/$(params.repo-name)
       - name: cicd-tools-image-url
-        value: quay.io/$(params.quay-namespace)/cicd-tools:0.1
+        value: quay.io/$(params.quay-namespace)/cicd-tools:0.2
       serviceAccountName: image-pusher
       timeout: 1h30m

--- a/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
+++ b/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
@@ -43,6 +43,7 @@ spec:
         value: quay.io/$(params.quay-namespace)/$(params.repo-name)-tools:latest
       - name: binary-image-url
         value: quay.io/$(params.quay-namespace)/$(params.repo-name)
-
+      - name: cicd-tools-image-url
+        value: quay.io/$(params.quay-namespace)/cicd-tools:0.1
       serviceAccountName: image-pusher
       timeout: 1h30m

--- a/toolchain-pipeline/pipeline/toolchain-cd-pipeline.yaml
+++ b/toolchain-pipeline/pipeline/toolchain-cd-pipeline.yaml
@@ -25,6 +25,8 @@ objects:
       type: string
     - name: binary-image-url
       type: string
+    - name: cicd-tools-image-url
+      type: string
 
     tasks:
     - name: fetch-repository
@@ -90,6 +92,8 @@ objects:
         value: $(params.repo-revision)
       - name: tools-image-url
         value: $(params.tools-image-url)
+      - name: cicd-tools-image-url
+        value: $(params.cicd-tools-image-url)
       runAfter:
       - build-project
 parameters:


### PR DESCRIPTION
This PR changes the step that generates and pushes new manifests - there are two steps now:
* `generate-cd-release-manifests` 
   * generates the manifests for the next release
   * pushes the manifests as an application to quay

* `push-bundle-and-index-image` 
    * uses the generated manifests from the previous step and builds and pushes bundle image + adds the bundle to index image
