### PR TITLE
chore: ignore app push errors & increase cpu limit

### DIFF
--- a/toolchain-pipeline/01-toolchain-cd-tasks.yaml
+++ b/toolchain-pipeline/01-toolchain-cd-tasks.yaml
@@ -123,11 +123,14 @@ spec:
       privileged: true
     workingDir: '$(workspaces.source.path)/$(params.repo-path)/'
     image: $(params.tools-image-url)
+    resources:
+      limits:
+        cpu: 800m
     script: |
       #!/bin/sh
       set -e
       make generate-cd-release-manifests QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
-      make push-manifests-as-app QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp
+      make push-manifests-as-app QUAY_NAMESPACE=$(params.quay-namespace) TMP_DIR=$(workspaces.source.path)/$(params.repo-path)/tmp || true
 
   - name: push-bundle-and-index-image
     volumeMounts:


### PR DESCRIPTION
* ignores any errors while pushing manifests as an app to quay
* increases the cpu limit to make the generation faster