### PR TITLE
fix: replace removed name with ref

### DIFF
--- a/sync/05-eventlistener.yaml
+++ b/sync/05-eventlistener.yaml
@@ -11,7 +11,7 @@ spec:
     - cel:
         filter: header.match('X-GitHub-Event', 'push') && body.ref.startsWith('refs/heads/master')
     bindings:
-      - name: toolchain-cicd-sync-binding
+      - ref: toolchain-cicd-sync-binding
     template:
       name: toolchain-cicd-sync-template
 
@@ -20,7 +20,7 @@ spec:
     - cel:
         filter: header.match('X-GitHub-Event', 'pull_request') && body.action == 'opened' || body.action == 'synchronize'
     bindings:
-      - name: toolchain-cicd-dry-run-binding
+      - ref: toolchain-cicd-dry-run-binding
     template:
       name: toolchain-cicd-dry-run-template
 ---

--- a/toolchain-pipeline/04-eventlistener.yaml
+++ b/toolchain-pipeline/04-eventlistener.yaml
@@ -8,7 +8,7 @@ spec:
   triggers:
   - name: toolchain-cd-pipeline
     bindings:
-      - name: toolchain-cd-pipeline-binding
+      - ref: toolchain-cd-pipeline-binding
     template:
       name: toolchain-cd-pipeline-template
 ---


### PR DESCRIPTION
The `name` in `EventListener` was deprecated some time ago and in 4.6 it was completely removed. I replaced it with `ref`