### PR TITLE
fix: we need to newly reference the TriggerTemplate

### DIFF
--- a/sync/06-trigger-templates.yaml
+++ b/sync/06-trigger-templates.yaml
@@ -27,15 +27,15 @@ spec:
         name: toolchain-cicd-pipeline
       params:
       - name: repo
-        value: $(params.fullname)
+        value: $(tt.params.fullname)
       - name: commit-sha
-        value: $(params.gitsha)
+        value: $(tt.params.gitsha)
       - name: pipeline-run-name
         value: toolchain-cicd-sync-$(uid)
       - name: dry-run
         value: "false"
       - name: repo-url
-        value: $(params.gitrepositoryurl)
+        value: $(tt.params.gitrepositoryurl)
       - name: quay-namespace
         value: codeready-toolchain
 ---
@@ -57,7 +57,7 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: toolchain-cicd-dry-run-pr$(params.prnumber)-$(uid)
+      name: toolchain-cicd-dry-run-pr$(tt.params.prnumber)-$(uid)
     spec:
       workspaces:
       - name: shared-workspace
@@ -67,14 +67,14 @@ spec:
         name: toolchain-cicd-pipeline
       params:
       - name: repo
-        value: $(params.fullname)
+        value: $(tt.params.fullname)
       - name: commit-sha
-        value: $(params.gitsha)
+        value: $(tt.params.gitsha)
       - name: pipeline-run-name
-        value: toolchain-cicd-dry-run-pr$(params.prnumber)-$(uid)
+        value: toolchain-cicd-dry-run-pr$(tt.params.prnumber)-$(uid)
       - name: dry-run
         value: "true"
       - name: repo-url
-        value: $(params.gitrepositoryurl)
+        value: $(tt.params.gitrepositoryurl)
       - name: quay-namespace
         value: codeready-toolchain

--- a/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
+++ b/toolchain-pipeline/03-toolchain-cd-pipeline-template.yaml
@@ -20,30 +20,30 @@ spec:
   - apiVersion: tekton.dev/v1beta1
     kind: PipelineRun
     metadata:
-      name: toolchain-cd-$(params.repo-name)-$(uid)
+      name: toolchain-cd-$(tt.params.repo-name)-$(uid)
     spec:
       workspaces:
       - name: shared-workspace
         persistentVolumeClaim:
           claimName: pipeline-resources
       pipelineRef:
-        name: $(params.repo-name)-cd
+        name: $(tt.params.repo-name)-cd
       params:
       - name: repo-url
-        value: $(params.clone-url)
+        value: $(tt.params.clone-url)
       - name: repo-name
-        value: $(params.repo-name)
+        value: $(tt.params.repo-name)
       - name: repo-revision
-        value: $(params.repo-revision)
+        value: $(tt.params.repo-revision)
       - name: repo-path
-        value: 'go/src/github.com/codeready-toolchain/$(params.repo-name)'
+        value: 'go/src/github.com/codeready-toolchain/$(tt.params.repo-name)'
       - name: quay-namespace
-        value: $(params.quay-namespace)
+        value: $(tt.params.quay-namespace)
       - name: tools-image-url
-        value: quay.io/$(params.quay-namespace)/$(params.repo-name)-tools:latest
+        value: quay.io/$(tt.params.quay-namespace)/$(tt.params.repo-name)-tools:latest
       - name: binary-image-url
-        value: quay.io/$(params.quay-namespace)/$(params.repo-name)
+        value: quay.io/$(tt.params.quay-namespace)/$(tt.params.repo-name)
       - name: cicd-tools-image-url
-        value: quay.io/$(params.quay-namespace)/cicd-tools:0.2
+        value: quay.io/$(tt.params.quay-namespace)/cicd-tools:0.2
       serviceAccountName: image-pusher
       timeout: 1h30m


### PR DESCRIPTION
It looks like that in the new version of pipelines, we need to reference a TriggerTemplate when using the parameters