### PR TITLE
chore: use opm 1.16.1

### DIFF
--- a/prepare-tools-action/action.yml
+++ b/prepare-tools-action/action.yml
@@ -12,7 +12,7 @@ inputs:
   opm-version:
     description: Version of opm binary
     required: false
-    default: v1.12.5
+    default: v1.16.1
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
use latest version of opm - 1.16.1
related PR: https://github.com/codeready-toolchain/api/pull/218