### PR TITLE
feat: migrate CICD to operator-sdk 1.8.0

### DIFF
--- a/prepare-tools-action/action.yml
+++ b/prepare-tools-action/action.yml
@@ -4,11 +4,7 @@ inputs:
   operator-sdk-version:
     description: Version of operator-sdk binary
     required: false
-    default: v0.19.2
-  operator-sdk-gpg-key:
-    description: Gpg key to use to verify operator-sdk binary
-    required: false
-    default: 9AF46519
+    default: v1.8.0
   opm-version:
     description: Version of opm binary
     required: false
@@ -30,10 +26,11 @@ runs:
       set -ex
 
       # download, verify and install operator-sdk
-      curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.operator-sdk-version }}/operator-sdk-${{ inputs.operator-sdk-version }}-x86_64-linux-gnu -o operator-sdk \
-        && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.operator-sdk-version }}/operator-sdk-${{ inputs.operator-sdk-version }}-x86_64-linux-gnu.asc -o operator-sdk.asc \
-        && gpg --keyserver keyserver.ubuntu.com --recv-key ${{ inputs.operator-sdk-gpg-key }} \
-        && gpg --verify operator-sdk.asc \
+      curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.operator-sdk-version }}/operator-sdk_linux_amd64 -o operator-sdk \
+        && gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E \
+        && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.operator-sdk-version }}/checksums.txt -o checksums.txt \
+        && curl -L -s https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.operator-sdk-version }}/checksums.txt.asc -o checksums.txt.asc \
+        && gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc \
         && chmod +x operator-sdk \
         && sudo cp operator-sdk /bin/operator-sdk \
         && rm operator-sdk \

--- a/publish-operators-for-e2e-tests/action.yml
+++ b/publish-operators-for-e2e-tests/action.yml
@@ -1,0 +1,34 @@
+name: 'Publish Current Toolchain Operators (Host & Member)'
+description: 'An action that publishes the current version of Toolchain Operators as single releases'
+inputs:
+  quay-token:
+    description: Quay token
+    required: true
+  quay-namespace:
+    description: Quay namespace
+    required: false
+    default: codeready-toolchain
+runs:
+  using: "composite"
+  steps:
+  - name: Login to quay
+    shell: bash
+    run: |
+      set -e
+      mkdir -p  ~/.docker || true
+      echo "{
+                    \"auths\": {
+                            \"quay.io\": {
+                                    \"auth\": \"${{ inputs.quay-token }}\"
+                            }
+                    }
+            }"> ~/.docker/config.json
+
+      podman login quay.io  --authfile=~/.docker/config.json
+
+  - name: Publish current bundle for e2e tests
+    shell: bash
+    run: |
+      if [[ -n $(grep "publish-current-bundles-for-e2e" make/* || true) ]]; then
+        make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman
+      fi

--- a/publish-operators-for-e2e-tests/action.yml
+++ b/publish-operators-for-e2e-tests/action.yml
@@ -29,6 +29,4 @@ runs:
   - name: Publish current bundle for e2e tests
     shell: bash
     run: |
-      if [[ -n $(grep "publish-current-bundles-for-e2e" make/* || true) ]]; then
-        make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ github.event.pull_request.head.sha }}
-      fi
+      make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ github.event.pull_request.head.sha }}

--- a/publish-operators-for-e2e-tests/action.yml
+++ b/publish-operators-for-e2e-tests/action.yml
@@ -30,5 +30,5 @@ runs:
     shell: bash
     run: |
       if [[ -n $(grep "publish-current-bundles-for-e2e" make/* || true) ]]; then
-        make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman
+        make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ github.event.pull_request.head.sha }}
       fi


### PR DESCRIPTION
* Updates CD action to use latest operator-sdk
* Adds new GH action that builds & pushes operator bundles for e2e tests to quay