### PR TITLE
chore: set FIRST_RELEASE to true to initialize the index images

### DIFF
--- a/release-operator-action/action.yml
+++ b/release-operator-action/action.yml
@@ -39,4 +39,4 @@ runs:
 
       make generate-cd-release-manifests QUAY_NAMESPACE=${{ inputs.quay-namespace }}
 
-      make push-bundle-and-index-image QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman
+      make push-bundle-and-index-image QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman FIRST_RELEASE=true


### PR DESCRIPTION
I cannot initialize the index image manually, because I would need to reference the name of the bundle images that already exist and are in use.
Will set remove it as soon as I will make the first releases for both new index images