### PR TITLE
fix: add author var

### DIFF
--- a/publish-operators-for-e2e-tests/action.yml
+++ b/publish-operators-for-e2e-tests/action.yml
@@ -29,4 +29,4 @@ runs:
   - name: Publish current bundle for e2e tests
     shell: bash
     run: |
-      make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ github.event.pull_request.head.sha }} PULL_NUMBER=${{ github.event.pull_request.number }}
+      make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ github.event.pull_request.head.sha }} PULL_NUMBER=${{ github.event.pull_request.number }} AUTHOR=${{ github.event.pull_request.head.user.login }}


### PR DESCRIPTION
because we need to know the name of the author of a PR - right now, we use `GITHUB_ACTOR` var provided by the GH Actions env, however, that var contains a name of a persons who triggers the event (for example clicks on a button in GH Actions UI) and not the owner of the PR