### PR TITLE
feat: add all ci/cd scripts

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+
+set -e
+
+user_help () {
+    echo "Creates ToolchainCluster"
+    echo "options:"
+    echo "-t, --type            joining cluster type (host or member)"
+    echo "-tn, --type-name      the type name of the joining cluster (host, member or e2e)"
+    echo "-tc, --target-cluster the name of the cluster it should join to - applicable only together with '--sandbox-config' param (host, member1, member2,...)"
+    echo "-mn, --member-ns      namespace where member-operator is running"
+    echo "-hn, --host-ns        namespace where host-operator is running"
+    echo "-s,  --single-cluster running both operators on single cluster"
+    echo "-mm, --multi-member   enables deploying multiple members in a single cluster, provide a unique id that will be used as a suffix for additional member cluster names"
+    echo "-kc, --kube-config    kubeconfig for managing multiple clusters"
+    echo "-sc, --sandbox-config sandbox config file for managing Dev Sandbox instance - applicable only together with '--target-cluster' param"
+    echo "-le, --lets-encrypt   use let's encrypt certificate"
+    exit 0
+}
+
+login_to_cluster() {
+    if [[ ${SINGLE_CLUSTER} != "true" ]]; then
+      if [[ -z ${KUBECONFIG} ]] && [[ -z ${SANDBOX_CONFIG} ]]; then
+        echo "Please specify the path to kube config file using the parameter --kube-config"
+        echo "or specify SA tokens to be used when reaching operators using the parameters --host-token and --member-token"
+      elif [[ -n ${KUBECONFIG} ]]; then
+        oc config use-context "$1-admin"
+      else
+        REGISTER_SERVER_API=$(yq -r .\"$1\".serverAPI ${SANDBOX_CONFIG})
+        REGISTER_SA_TOKEN=$(yq -r .\"$1\".tokens.registerCluster ${SANDBOX_CONFIG})
+        OC_ADDITIONAL_PARAMS="--token=${REGISTER_SA_TOKEN} --server=${REGISTER_SERVER_API}"
+      fi
+    fi
+}
+
+create_service_account() {
+# we need to delete the bindings since we cannot change the roleRef of the existing bindings
+if [[ -n `oc get rolebinding ${SA_NAME} 2>/dev/null` ]]; then
+    oc delete rolebinding ${SA_NAME} -n ${OPERATOR_NS} ${OC_ADDITIONAL_PARAMS}
+fi
+
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+EOF
+
+if [[ ${JOINING_CLUSTER_TYPE} == "host" ]]; then
+    cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "bannedusers"
+  - "changetierrequests"
+  - "hostoperatorconfigs"
+  - "masteruserrecords"
+  - "notifications"
+  - "nstemplatetiers"
+  - "registrationservices"
+  - "templateupdaterequests"
+  - "tiertemplates"
+  - "toolchainconfigs"
+  - "toolchainclusters"
+  - "toolchainstatuses"
+  - "usersignups"
+  verbs:
+  - "*"
+EOF
+else
+    cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "idlers"
+  - "nstemplatesets"
+  - "memberoperatorconfigs"
+  - "memberstatuses"
+  - "toolchainclusters"
+  - "useraccounts"
+  verbs:
+  - "*"
+EOF
+fi
+
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+subjects:
+- kind: ServiceAccount
+  name: ${SA_NAME}
+roleRef:
+  kind: Role
+  name: ${SA_NAME}
+  apiGroup: rbac.authorization.k8s.io
+EOF
+}
+
+create_service_account_e2e() {
+CLUSTER_ROLE_BINDING_NAME=${SA_NAME}-${OPERATOR_NS}
+# we need to delete the binding since we cannot change the roleRef of the existing binding
+if [[ -n `oc get ClusterRoleBinding ${CLUSTER_ROLE_BINDING_NAME} 2>/dev/null` ]]; then
+    oc delete ClusterRoleBinding ${CLUSTER_ROLE_BINDING_NAME} ${OC_ADDITIONAL_PARAMS}
+fi
+echo "Creating SA ${SA_NAME}"
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+EOF
+
+echo "Creating ClusterRoleBinding ${CLUSTER_ROLE_BINDING_NAME}"
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${CLUSTER_ROLE_BINDING_NAME}
+subjects:
+- kind: ServiceAccount
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+}
+
+if [[ $# -lt 2 ]]
+then
+    user_help
+fi
+
+while test $# -gt 0; do
+       case "$1" in
+            -h|--help)
+                user_help
+                ;;
+            -t|--type)
+                shift
+                JOINING_CLUSTER_TYPE=$1
+                shift
+                ;;
+            -tn|--type-name)
+                shift
+                JOINING_CLUSTER_TYPE_NAME=$1
+                shift
+                ;;
+            -tc|--target-cluster)
+                shift
+                TARGET_CLUSTER_NAME=$1
+                shift
+                ;;
+            -mn|--member-ns)
+                shift
+                MEMBER_OPERATOR_NS=$1
+                shift
+                ;;
+            -hn|--host-ns)
+                shift
+                HOST_OPERATOR_NS=$1
+                shift
+                ;;
+            -kc|--kube-config)
+                shift
+                KUBECONFIG=$1
+                shift
+                ;;
+            -sc|--sandbox-config)
+                shift
+                SANDBOX_CONFIG=$1
+                shift
+                ;;
+            -s|--single-cluster)
+                SINGLE_CLUSTER=true
+                shift
+                ;;
+            -mm|--multi-member)
+                shift
+                MULTI_MEMBER=$1
+                shift
+                ;;
+            -le|--lets-encrypt)
+                LETS_ENCRYPT=true
+                shift
+                ;;
+            *)
+               echo "$1 is not a recognized flag!"
+               user_help
+               exit -1
+               ;;
+      esac
+done
+
+CLUSTER_JOIN_TO="host"
+
+if [[ -n ${SANDBOX_CONFIG} ]]; then
+    OPERATOR_NS=$(yq -r .\"${JOINING_CLUSTER_TYPE}\".sandboxNamespace ${SANDBOX_CONFIG})
+    CLUSTER_JOIN_TO_OPERATOR_NS=$(yq -r .\"${TARGET_CLUSTER_NAME}\".sandboxNamespace ${SANDBOX_CONFIG})
+    CLUSTER_JOIN_TO=${TARGET_CLUSTER_NAME}
+else
+    # We need this to configurable to work with dynamic namespaces from end to end tests
+    OPERATOR_NS=${MEMBER_OPERATOR_NS}
+    CLUSTER_JOIN_TO_OPERATOR_NS=${HOST_OPERATOR_NS}
+    if [[ ${JOINING_CLUSTER_TYPE} == "host" ]]; then
+      CLUSTER_JOIN_TO="member"
+      OPERATOR_NS=${HOST_OPERATOR_NS}
+      CLUSTER_JOIN_TO_OPERATOR_NS=${MEMBER_OPERATOR_NS}
+    fi
+
+    # This is using default values i.e. toolchain-member-operator or toolchain-host-operator for local setup
+    if [[ ${OPERATOR_NS} == "" &&  ${CLUSTER_JOIN_TO_OPERATOR_NS} == "" ]]; then
+      OPERATOR_NS=toolchain-${JOINING_CLUSTER_TYPE}-operator
+      CLUSTER_JOIN_TO_OPERATOR_NS=toolchain-${CLUSTER_JOIN_TO}-operator
+    fi
+fi
+JOINING_CLUSTER_TYPE_NAME=${JOINING_CLUSTER_TYPE_NAME:-${JOINING_CLUSTER_TYPE}}
+
+echo ${OPERATOR_NS}
+echo ${CLUSTER_JOIN_TO_OPERATOR_NS}
+
+login_to_cluster ${JOINING_CLUSTER_TYPE}
+
+if [[ ${JOINING_CLUSTER_TYPE_NAME} != "e2e" ]]; then
+    SA_NAME="toolchaincluster-${JOINING_CLUSTER_TYPE_NAME}${MULTI_MEMBER}"
+    create_service_account
+else
+    SA_NAME="e2e-service-account"
+    if [[ ! -z ${MULTI_MEMBER} ]]; then
+      SA_NAME="${OPERATOR_NS}"
+    fi
+    create_service_account_e2e
+fi
+
+echo "Getting ${JOINING_CLUSTER_TYPE} SA token"
+SA_SECRET=`oc get sa ${SA_NAME} -n ${OPERATOR_NS} -o json ${OC_ADDITIONAL_PARAMS} | jq -r .secrets[].name | grep token`
+SA_TOKEN=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS}  -o json ${OC_ADDITIONAL_PARAMS} | jq -r '.data["token"]' | base64 --decode`
+if [[ ${LETS_ENCRYPT} == "true" ]]; then
+    SA_CA_CRT=`curl https://letsencrypt.org/certs/lets-encrypt-r3.pem | base64 -w 0`
+else
+    SA_CA_CRT=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS} -o json ${OC_ADDITIONAL_PARAMS} | jq -r '.data["ca.crt"]'`
+fi
+
+if [[ -n ${SANDBOX_CONFIG} ]]; then
+    API_ENDPOINT=$(yq -r .\"${JOINING_CLUSTER_TYPE}\".serverAPI ${SANDBOX_CONFIG})
+    JOINING_CLUSTER_NAME=$(yq -r .\"${JOINING_CLUSTER_TYPE}\".serverName ${SANDBOX_CONFIG})
+
+    login_to_cluster ${CLUSTER_JOIN_TO}
+
+    CLUSTER_JOIN_TO_NAME=$(yq -r .\"${CLUSTER_JOIN_TO}\".serverName ${SANDBOX_CONFIG})
+else
+    API_ENDPOINT=`oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}' ${OC_ADDITIONAL_PARAMS}`
+    JOINING_CLUSTER_NAME=`echo "${API_ENDPOINT}" | sed 's/.*api\.\([^:]*\):.*/\1/'`
+
+    login_to_cluster ${CLUSTER_JOIN_TO}
+
+    CLUSTER_JOIN_TO_API_ENDPOINT=`oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}' ${OC_ADDITIONAL_PARAMS}`
+    CLUSTER_JOIN_TO_NAME=`echo "${CLUSTER_JOIN_TO_API_ENDPOINT}" | sed 's/.*api\.\([^:]*\):.*/\1/'`
+fi
+
+echo "Creating ${JOINING_CLUSTER_TYPE} secret"
+SECRET_NAME=${SA_NAME}-${JOINING_CLUSTER_NAME}
+if [[ -n `oc get secret -n ${CLUSTER_JOIN_TO_OPERATOR_NS} ${OC_ADDITIONAL_PARAMS} | grep ${SECRET_NAME}` ]]; then
+    oc delete secret ${SECRET_NAME} -n ${CLUSTER_JOIN_TO_OPERATOR_NS} ${OC_ADDITIONAL_PARAMS}
+fi
+oc create secret generic ${SECRET_NAME} --from-literal=token="${SA_TOKEN}" --from-literal=ca.crt="${SA_CA_CRT}" -n ${CLUSTER_JOIN_TO_OPERATOR_NS} ${OC_ADDITIONAL_PARAMS}
+
+TOOLCHAINCLUSTER_NAME=${JOINING_CLUSTER_TYPE_NAME}-${JOINING_CLUSTER_NAME}${MULTI_MEMBER}
+
+CLUSTER_JOIN_TO_TYPE_NAME=CLUSTER_JOIN_TO
+if [[ ${CLUSTER_JOIN_TO_TYPE_NAME} != "host" ]]; then
+    CLUSTER_JOIN_TO_TYPE_NAME="member"
+fi
+OWNER_CLUSTER_NAME=${CLUSTER_JOIN_TO_TYPE_NAME}-${CLUSTER_JOIN_TO_NAME}${MULTI_MEMBER}
+
+TOOLCHAINCLUSTER_CRD="apiVersion: toolchain.dev.openshift.com/v1alpha1
+kind: ToolchainCluster
+metadata:
+  name: ${TOOLCHAINCLUSTER_NAME}
+  namespace: ${CLUSTER_JOIN_TO_OPERATOR_NS}
+  labels:
+    type: ${JOINING_CLUSTER_TYPE_NAME}
+    namespace: ${OPERATOR_NS}
+    ownerClusterName: ${OWNER_CLUSTER_NAME}
+spec:
+  apiEndpoint: ${API_ENDPOINT}
+  caBundle: ${SA_CA_CRT}
+  secretRef:
+    name: ${SECRET_NAME}
+"
+
+echo "Creating ToolchainCluster representation of ${JOINING_CLUSTER_TYPE} in ${CLUSTER_JOIN_TO}:"
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+${TOOLCHAINCLUSTER_CRD}
+EOF

--- a/scripts/cd/enrich-by-envs-from-yaml.sh
+++ b/scripts/cd/enrich-by-envs-from-yaml.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+user_help () {
+    echo ""
+    echo "Usage: enrich-by-envs-from-yaml.sh [path/to/target/yaml/file/to/be/enriched] [path/to/source/yaml/file/containing/configuration/data]"
+    echo ""
+    echo "enrich-by-envs-from-yaml.sh adds fields that will set up environment variables for a deployment. The variables are taken from the conf yaml file specified as the source."
+    echo ""
+    echo "Examples:"
+    echo "   ./scripts/enrich-by-envs-from-yaml.sh ./path/to/csv.yaml ./path/to/e2e-test.yaml"
+    echo "          - Where e2e-test.yaml contain:"
+    echo ""
+    echo "--- e2e-test.yaml ------------------------------------------------------------"
+    echo "registration-service:
+  environment: 'e2e-tests'
+  auth-client:
+    library-url: 'https://sso.prod-preview.openshift.io/auth/js/keycloak.js'"
+    echo "------------------------------------------------------------------------------"
+    echo ""
+    echo "             then the script will append after the first occurrence of 'env:' inside of csv.yaml file:"
+    echo ""
+    echo "--- csv.yaml ----------------------------------------------------------------------"
+    echo " - name: REGISTRATION_SERVICE_AUTH_CLIENT_LIBRARY_URL
+   value: https://sso.redhat.com/auth/js/keycloak.js
+ - name: REGISTRATION_SERVICE_ENVIRONMENT
+   value: prod"
+   echo "------------------------------------------------------------------------------------"
+    echo ""
+    exit 0
+}
+
+keys_values_in_path() {
+    local LOCATION_PATH="$1"
+    local VAR_BASE_NAME="$2"
+
+    FOUND_KEYS=`cat ${SOURCE_YAML_FILE_PATH} | yq "${LOCATION_PATH}" | yq 'keys?'`
+
+    if [[ -z ${FOUND_KEYS} ]]; then
+        add_key_value_pair "${LOCATION_PATH}" "${VAR_BASE_NAME}"
+    else
+        for KEY in `yq '.[]' <<< ${FOUND_KEYS}`;
+        do
+            KEY_VAR_NAME=$(to_var_name ${KEY})
+            VAR_BASE_NAME_WITH_KEY="${VAR_BASE_NAME}_${KEY_VAR_NAME}"
+            if [[ -z ${VAR_BASE_NAME} ]]; then
+                VAR_BASE_NAME_WITH_KEY="${KEY_VAR_NAME}"
+            fi
+            keys_values_in_path "${LOCATION_PATH}[${KEY}]" "${VAR_BASE_NAME_WITH_KEY}"
+        done
+    fi
+}
+
+to_var_name() {
+    echo ${1} | awk '{ print toupper($0) }' | tr '-' '_'  | sed 's/\"//g'
+}
+
+add_key_value_pair() {
+    local LOCATION_PATH="$1"
+    local VAR_KEY_NAME="$2"
+
+    RESULT+="\n"
+    RESULT+="${INDENTATION}- name: ${VAR_KEY_NAME}\n"
+    VALUE=`cat ${SOURCE_YAML_FILE_PATH} | yq "${LOCATION_PATH}" | sed -e 's/^"//;s/"$//'`
+    RESULT+="${INDENTATION}  value: '${VALUE}'"
+}
+
+if [[ -z $1 ]]; then
+    echo "The path to the target yaml file is not specified" >> /dev/stderr
+    user_help
+    exit 1;
+fi
+
+if [[ -z $2 ]]; then
+    echo "The path to the config yaml file is not specified" >> /dev/stderr
+    user_help
+    exit 1;
+fi
+
+TARGET_YAML_FILE_PATH=$1
+SOURCE_YAML_FILE_PATH=$2
+
+if [[ ! -f ${SOURCE_YAML_FILE_PATH} ]]; then
+    echo "there is no file found at the path that should point to the yaml file containing configuration data ${SOURCE_YAML_FILE_PATH}" >> /dev/stderr
+    cat ${TARGET_YAML_FILE_PATH}
+else
+    if [[ -z $(command -v yq) ]]; then
+        echo "The binary yq is not available. To get the installation instructions please visit https://github.com/kislyuk/yq#installation" >> /dev/stderr
+        exit 1;
+    fi
+
+    INDENTATION=`grep -m 1 "env:" ${TARGET_YAML_FILE_PATH} | sed 's/env://'`
+
+    keys_values_in_path . ""
+
+    SED_REPLACEMENT="s|env:|env:${RESULT}|"
+    sed "${SED_REPLACEMENT}" ${TARGET_YAML_FILE_PATH}
+fi

--- a/scripts/cd/generate-cd-release-manifests.sh
+++ b/scripts/cd/generate-cd-release-manifests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/cd/olm-setup.sh
+OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
+
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}/${OLM_SETUP_FILE})"
+    fi
+fi
+
+# read argument to get project root dir
+read_arguments $@
+set -ex
+echo "arguments read"
+
+# setup version variables based on commits so they can be used for generation process
+setup_version_variables_based_on_commits
+
+echo "versions configured"
+
+# generate manifests
+check_main_and_embedded_repos_and_generate_manifests $@ --next-version ${NEXT_CSV_VERSION}

--- a/scripts/cd/olm-setup.sh
+++ b/scripts/cd/olm-setup.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -ex
+
+user_help () {
+    echo "Generate ClusterServiceVersion and additional deployment files for openshift-marketplace"
+    echo "options:"
+    echo "-pr, --project-root      Path to the root of the project the CSV should be generated for/in"
+    echo "-nv, --next-version      Semantic version of the new CSV to be created"
+    echo "-ch, --channel           Channel to be used for the CSV in the package manifest"
+    echo "-on, --operator-name     Name of the operator - by default it uses toolchain-{repository_name}"
+    echo "-mr, --main-repo         URL of the GH repo that should be used as the main repo (for CD). The current repo should be embedded in the main one. The operator bundle should be taken from the main repository (example of the main repo: https://github.com/codeready-toolchain/host-operator)"
+    echo "-er, --embedded-repo     URL of the GH repo that should be used as the embedded repo (for CD). The repository should be embedded in the current repo. The operator bundle should be taken from the current repository (example of the embedded repo: https://github.com/codeready-toolchain/registration-service)"
+    echo "-orp, --other-repo-path  Path to either embedded repo or main repo - it depends on which is specified. When the parameter is used, then the script won't clone the repo from master, but will use the version from the given path."
+    echo "-ori, --other-repo-image Image location of either embedded repo or main repo - it depends on which is specified."
+    echo "-qn, --quay-namespace    Specify the quay namespace the CSV should be pushed to - if not used then it uses the one stored in \"\${QUAY_NAMESPACE}\" variable"
+    echo "-n,  --namespace         Namespace operator should be installed in"
+    echo "-td, --temp-dir          Directory that should be used for storing temporal files - by default '/tmp' is used"
+    echo "-ib, --image-builder     Tool to build container images - will be used by opm. One of: [docker, podman] (default "docker")"
+    echo "-iin, --index-image-name Name of the index image the bundle image should be added to."
+    echo "-iit, --index-image-tag  Tag of the index image the bundle image should be added to."
+    echo "-il, --image-location    Image location of the operator binary."
+    echo "-bt, --bundle-tag        Tag of the bundle image."
+    echo "-fr, --first-release     If set to true, then it will generate CSV without replaces clause."
+    echo "-ci, --component-image   The name of the image to be used as a component of this operator."
+    echo "-e,  --env               Environment name to be set in operator CSV/deployment."
+    echo "-h,  --help              To show this help text"
+    echo ""
+    additional_help 2>/dev/null || true
+    exit 0
+}
+
+read_arguments() {
+    if [[ $# -lt 2 ]]
+    then
+        user_help
+    fi
+
+    while test $# -gt 0; do
+           case "$1" in
+                -h|--help)
+                    user_help
+                    ;;
+                -pr|--project-root)
+                    shift
+                    PRJ_ROOT_DIR=$1
+                    shift
+                    ;;
+                -nv|--next-version)
+                    shift
+                    NEXT_CSV_VERSION=$1
+                    shift
+                    ;;
+                -ch|--channel)
+                    shift
+                    CHANNEL=$1
+                    shift
+                    ;;
+                -on|--operator-name)
+                    shift
+                    SET_OPERATOR_NAME=$1
+                    shift
+                    ;;
+                -mr|--main-repo)
+                    shift
+                    MAIN_REPO_URL=$1
+                    shift
+                    ;;
+                -er|--embedded-repo)
+                    shift
+                    EMBEDDED_REPO_URL=$1
+                    shift
+                    ;;
+                -orp|--other-repo-path)
+                    shift
+                    OTHER_REPO_PATH=$1
+                    shift
+                    ;;
+                -ori|--other-repo-image)
+                    shift
+                    OTHER_REPO_IMAGE_LOC=$1
+                    shift
+                    ;;
+                -qn|--quay-namespace)
+                    shift
+                    QUAY_NAMESPACE_TO_PUSH=$1
+                    shift
+                    ;;
+                -n|--namespace)
+                    shift
+                    NAMESPACE=$1
+                    shift
+                    ;;
+                -td|--temp-dir)
+                    shift
+                    TEMP_DIR=$1
+                    shift
+                    ;;
+                -ib|--image-builder)
+                    shift
+                    IMAGE_BUILDER=$1
+                    shift
+                    ;;
+                -iin|--index-image-name)
+                    shift
+                    INDEX_IMAGE_NAME=$1
+                    shift
+                    ;;
+                -iit|--index-image-tag)
+                    shift
+                    INDEX_IMAGE_TAG=$1
+                    shift
+                    ;;
+                -il|--image-location)
+                    shift
+                    IMAGE_LOCATION=$1
+                    shift
+                    ;;
+                -bt|--bundle-tag)
+                    shift
+                    BUNDLE_TAG=$1
+                    shift
+                    ;;
+                -fr|--first-release)
+                    shift
+                    FIRST_RELEASE=$1
+                    shift
+                    ;;
+                -ci|--component-image)
+                    shift
+                    COMPONENT_IMAGE=$1
+                    shift
+                    ;;
+                -e|--env)
+                    shift
+                    ENV=$1
+                    shift
+                    ;;
+                *)
+                   echo "$1 is not a recognized flag!" >> /dev/stderr
+                   user_help
+                   exit -1
+                   ;;
+          esac
+    done
+
+    if [[ -z ${PRJ_ROOT_DIR} ]]; then
+        echo "--project-root parameter is not specified" >> /dev/stderr
+        user_help
+        exit 1;
+    fi
+
+    cd ${PRJ_ROOT_DIR}
+    PRJ_ROOT_DIR=${PWD}
+    cd - > /dev/null
+
+    if [[ -n "${EMBEDDED_REPO_URL}" ]] && [[ -n "${MAIN_REPO_URL}" ]]; then
+        echo "you cannot specify both parameters '--main-repo' and '--embedded-repo' at the same time - use only one" >> /dev/stderr
+        user_help
+        exit 1
+    fi
+
+    if [[ -z ${QUAY_NAMESPACE_TO_PUSH} ]]; then
+        QUAY_NAMESPACE_TO_PUSH=${QUAY_NAMESPACE:codeready-toolchain}
+    fi
+
+    setup_variables
+}
+
+# Default version var - it has to be out of the function to make it available in help text
+DEFAULT_VERSION=0.0.1
+
+setup_variables() {
+    # Version vars
+    NEXT_CSV_VERSION=${NEXT_CSV_VERSION:-${DEFAULT_VERSION}}
+
+    # Channel to be used
+    CHANNEL=${CHANNEL:alpha}
+
+    # Temporal directory
+    TEMP_DIR=${TEMP_DIR:-/tmp}
+    if [[ "${TEMP_DIR}" != "/tmp" ]]; then
+        mkdir -p ${TEMP_DIR} || true
+    fi
+    OTHER_REPO_ROOT_DIR=${TEMP_DIR}/cd/other-repo
+
+    # Image builder
+    IMAGE_BUILDER=${IMAGE_BUILDER:-"docker"}
+
+    # Files and directories related vars
+    PRJ_NAME=`basename ${PRJ_ROOT_DIR}`
+    OPERATOR_NAME=${SET_OPERATOR_NAME:-toolchain-${PRJ_NAME}}
+    MANIFESTS_DIR=${PRJ_ROOT_DIR}/bundle/manifests
+    CURRENT_DIR=${PWD}
+
+    export GO111MODULE=on
+}
+
+generate_bundle() {
+    echo "## Generating operator bundle of project '${PRJ_NAME}' ..."
+
+    make -C ${PRJ_ROOT_DIR} bundle CHANNEL=${CHANNEL} NEXT_VERSION=${NEXT_CSV_VERSION}
+
+    if [[ ${FIRST_RELEASE} != "true" ]] && [[ -n "${REPLACE_CSV_VERSION}" ]]; then
+        REPLACE_CLAUSE="replaces: ${OPERATOR_NAME}.v${REPLACE_CSV_VERSION}"
+        CSV_SED_REPLACE+=";s/^  version: /  ${REPLACE_CLAUSE}\n  version: /"
+    fi
+
+    if [[ -n "${IMAGE_IN_CSV}" ]]; then
+        # digest format removed for now as it brought more pain than benefits
+        # IMAGE_IN_CSV_DIGEST_FORMAT=`get_digest_format ${IMAGE_IN_CSV}`
+        CSV_SED_REPLACE+=";s|REPLACE_IMAGE|${IMAGE_IN_CSV}|g;s|REPLACE_CREATED_AT|$(date -u +%FT%TZ)|g;"
+    fi
+    if [[ -n "${EMBEDDED_REPO_IMAGE}" ]]; then
+        # digest format removed for now as it brought more pain than benefits
+        # EMBEDDED_REPO_IMAGE_DIGEST_FORMAT=`get_digest_format ${EMBEDDED_REPO_IMAGE}`
+        CSV_SED_REPLACE+=";s|${EMBEDDED_REPO_REPLACEMENT}|${EMBEDDED_REPO_IMAGE}|g;"
+    fi
+    if [[ ${PRJ_NAME} == "member-operator" ]]; then
+        COMPONENT_IMAGE_URL=${COMPONENT_IMAGE:-quay.io/${QUAY_NAMESPACE_TO_PUSH}/member-operator-webhook:${GIT_COMMIT_ID}}
+        # digest format removed for now as it brought more pain than benefits
+        # COMPONENT_IMAGE_DIGEST_FORMAT=`get_digest_format ${COMPONENT_IMAGE_URL}`
+        CSV_SED_REPLACE+=";s|REPLACE_MEMBER_OPERATOR_WEBHOOK_IMAGE|${COMPONENT_IMAGE_URL}|g;"
+    fi
+    if [[ "${CHANNEL}" == "staging" ]]; then
+        CSV_SED_REPLACE+=";s|  annotations:|  annotations:\n    olm.skipRange: '<${NEXT_CSV_VERSION}'|g;"
+    fi
+
+    CSV_LOCATION=${MANIFESTS_DIR}/*clusterserviceversion.yaml
+    replace_with_sed "${CSV_SED_REPLACE}" "${CSV_LOCATION}"
+    if [[ -n "${ENV}" ]]; then
+        CONFIG_ENV_FILE=${PRJ_ROOT_DIR}/deploy/env/${ENV}.yaml
+
+        echo "enriching ${CSV_LOCATION} by params defined in ${CONFIG_ENV_FILE}"
+        enrich-by-envs-from-yaml ${CSV_LOCATION} ${CONFIG_ENV_FILE}
+    fi
+
+    echo "-> Bundle generated."
+}
+
+# digest format removed for now as it brought more pain than benefits
+#get_digest_format() {
+#    IMG=$1
+#    IMG_LOC=`echo ${IMG} | cut -d: -f1`
+#
+#    IMG_ORG=`echo ${IMG_LOC} | awk -F/ '{print $2}'`
+#    IMG_NAME=`echo ${IMG_LOC} | awk -F/ '{print $3}'`
+#    IMG_TAG=`echo ${IMG} | cut -d: -f2`
+#
+#    echo "Getting digest of the image ${IMG}" >> /dev/stderr
+#
+#    while [[ -z ${IMG_DIGEST} || "${IMG_DIGEST}" == "null" ]]; do
+#		if [[ ${NEXT_WAIT_TIME} -eq 10 ]]; then
+#		   echo " the digest of the image ${IMG} wasn't found" >> /dev/stderr
+#		   exit 1
+#		fi
+#		echo -n "." >> /dev/stderr
+#		(( NEXT_WAIT_TIME++ ))
+#		sleep 1
+#		IMG_DIGEST=`curl https://quay.io/api/v1/repository/${IMG_ORG}/${IMG_NAME} 2>/dev/null | jq -r ".tags.\"${IMG_TAG}\".manifest_digest"`
+#	done
+#    echo " found: ${IMG_DIGEST}" >> /dev/stderr
+#
+#    echo ${IMG_LOC}@${IMG_DIGEST}
+#}
+
+
+enrich-by-envs-from-yaml() {
+    ENRICHED_CSV="${TEMP_DIR}/${OPERATOR_NAME}_${NEXT_CSV_VERSION}-enriched-file"
+
+    ENRICH_BY_ENVS_FROM_YAML=scripts/enrich-by-envs-from-yaml.sh
+    if [[ -f ${ENRICH_BY_ENVS_FROM_YAML} ]]; then
+        ${ENRICH_BY_ENVS_FROM_YAML} $@ > ${ENRICHED_CSV}
+    else
+        if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/api/${ENRICH_BY_ENVS_FROM_YAML} ]]; then
+            ${GOPATH}/src/github.com/codeready-toolchain/api/${ENRICH_BY_ENVS_FROM_YAML} $@ > ${ENRICHED_CSV}
+        else
+            curl -sSL  https://raw.githubusercontent.com/codeready-toolchain/api/master/${ENRICH_BY_ENVS_FROM_YAML} | bash -s -- $@ > ${ENRICHED_CSV}
+        fi
+    fi
+    cat ${ENRICHED_CSV} > $1
+}
+
+replace_with_sed() {
+    TMP_CSV="${TEMP_DIR}/${OPERATOR_NAME}_${NEXT_CSV_VERSION}_replace-file"
+    sed -e "$1" $2 > ${TMP_CSV}
+    cat ${TMP_CSV} > $2
+    rm -rf ${TMP_CSV}
+}
+
+# it takes one boolean parameter - if the other repo (either embedded or main one) should be cloned or not
+setup_version_variables_based_on_commits() {
+    # setup version and commit variables for the current repo
+    GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short HEAD`
+    PREVIOUS_GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short HEAD^`
+    NUMBER_OF_COMMITS=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-list --count HEAD`
+
+    # check if there is main repo or inner repo specified
+    if [[ -n "${MAIN_REPO_URL}${EMBEDDED_REPO_URL}" ]]; then
+        if [[ -z "${OTHER_REPO_PATH}" ]]; then
+            # if there is, then clone the latest version of the repo to ${TEMP_DIR} dir
+            if [[ -d ${OTHER_REPO_ROOT_DIR} ]]; then
+                rm -rf ${OTHER_REPO_ROOT_DIR}
+            fi
+            mkdir -p ${OTHER_REPO_ROOT_DIR}
+            git -C ${OTHER_REPO_ROOT_DIR} clone ${MAIN_REPO_URL}${EMBEDDED_REPO_URL}
+
+            OTHER_REPO_PATH=${OTHER_REPO_ROOT_DIR}/`basename -s .git $(echo ${MAIN_REPO_URL}${EMBEDDED_REPO_URL})`
+        fi
+
+
+        # and set version and comit variables also for this repo
+        OTHER_REPO_GIT_COMMIT_ID=`git --git-dir=${OTHER_REPO_PATH}/.git --work-tree=${OTHER_REPO_PATH} rev-parse --short HEAD`
+        OTHER_REPO_NUMBER_OF_COMMITS=`git --git-dir=${OTHER_REPO_PATH}/.git --work-tree=${OTHER_REPO_PATH} rev-list --count HEAD`
+
+        if [[ -n "${MAIN_REPO_URL}"  ]]; then
+            # the other repo is main, so the number of commits and commit ID should be specified as the first one
+            NEXT_CSV_VERSION="0.0.${OTHER_REPO_NUMBER_OF_COMMITS}-${NUMBER_OF_COMMITS}-commit-${OTHER_REPO_GIT_COMMIT_ID}-${GIT_COMMIT_ID}"
+            REPLACE_CSV_VERSION="0.0.${OTHER_REPO_NUMBER_OF_COMMITS}-$((${NUMBER_OF_COMMITS}-1))-commit-${OTHER_REPO_GIT_COMMIT_ID}-${PREVIOUS_GIT_COMMIT_ID}"
+        else
+            # the other repo is inner, so the number of commits and commit ID should be specified as the second one
+            NEXT_CSV_VERSION="0.0.${NUMBER_OF_COMMITS}-${OTHER_REPO_NUMBER_OF_COMMITS}-commit-${GIT_COMMIT_ID}-${OTHER_REPO_GIT_COMMIT_ID}"
+            REPLACE_CSV_VERSION="0.0.$((${NUMBER_OF_COMMITS}-1))-${OTHER_REPO_NUMBER_OF_COMMITS}-commit-${PREVIOUS_GIT_COMMIT_ID}-${OTHER_REPO_GIT_COMMIT_ID}"
+        fi
+    else
+        # there is no other repo specified - use the basic version format
+        NEXT_CSV_VERSION="0.0.${NUMBER_OF_COMMITS}-commit-${GIT_COMMIT_ID}"
+        REPLACE_CSV_VERSION="0.0.$((${NUMBER_OF_COMMITS}-1))-commit-${PREVIOUS_GIT_COMMIT_ID}"
+    fi
+    echo ${REPLACE_CSV_VERSION} ${NEXT_CSV_VERSION}
+}
+
+check_main_and_embedded_repos_and_generate_manifests() {
+    #read arguments and setup variables
+    read_arguments $@
+    setup_variables
+
+    IMAGE_IN_CSV=${IMAGE_LOCATION:-quay.io/${QUAY_NAMESPACE_TO_PUSH}/${PRJ_NAME}:${GIT_COMMIT_ID}}
+    # check if there is main repo or inner repo specified
+    if [[ -n ${MAIN_REPO_URL}${EMBEDDED_REPO_URL}  ]] && [[ -n ${OTHER_REPO_GIT_COMMIT_ID} ]]; then
+
+        OTHER_REPO_NAME=`basename -s .git $(echo ${MAIN_REPO_URL}${EMBEDDED_REPO_URL})`
+
+        if [[ -n "${MAIN_REPO_URL}"  ]]; then
+            EMBEDDED_REPO_IMAGE=${IMAGE_IN_CSV}
+
+            IMAGE_IN_CSV=quay.io/${QUAY_NAMESPACE_TO_PUSH}/${OTHER_REPO_NAME}:${OTHER_REPO_GIT_COMMIT_ID}
+            if [[ -n "${OTHER_REPO_IMAGE_LOC}" ]]; then
+                IMAGE_IN_CSV=${OTHER_REPO_IMAGE_LOC}
+            fi
+
+            EMBEDDED_REPO_REPLACEMENT=REPLACE_$(echo ${PRJ_NAME} | awk '{ print toupper($0) }' | tr '-' '_')_IMAGE
+            generate_manifests $@ -pr ${OTHER_REPO_PATH}
+        else
+            EMBEDDED_REPO_REPLACEMENT=REPLACE_$(echo ${OTHER_REPO_NAME} | awk '{ print toupper($0) }' | tr '-' '_')_IMAGE
+            EMBEDDED_REPO_IMAGE=quay.io/${QUAY_NAMESPACE_TO_PUSH}/${OTHER_REPO_NAME}:${OTHER_REPO_GIT_COMMIT_ID}
+            if [[ -n "${OTHER_REPO_IMAGE_LOC}" ]]; then
+                EMBEDDED_REPO_IMAGE=${OTHER_REPO_IMAGE_LOC}
+            fi
+            generate_manifests $@
+        fi
+    else
+        generate_manifests $@
+    fi
+}
+
+generate_manifests() {
+    #read arguments and setup variables
+    read_arguments $@
+    setup_variables
+
+    # generate the bundle
+    generate_bundle
+}

--- a/scripts/cd/push-bundle-and-index-image.sh
+++ b/scripts/cd/push-bundle-and-index-image.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+
+handle_missing_version_in_combined_repo() {
+    # split the version to get the number of commits and commit hashes as separated params (ie. from 0.0.217-105-commit-6c9926d-64af1be to 0.0.217 105 commit 6c9926d 64af1be)
+    SPLIT_REPLACE_VERSION=(${REPLACE_VERSION_SUFFIX//-/ })
+    # check if the number of split parts in the array is 5 to handle the missing version only for cases with embedded or main repos (host-operator + registration-service)
+    if [[ ${#SPLIT_REPLACE_VERSION[@]} -eq 5 ]]; then
+        # now we need to get the latest version that was added to the index - to do that we use "opm index export" command that pulls the index and all bundles that are added to the index
+        # however, we don't want to pull all bundle images (it could take long time and consume a lot of resources) so we redirect the output of the command to a file
+        # and then we will wait until opm unpacks the index image and prints out the list of bundle images that it is going to pull.
+        # We expect that the last added bundle is the first in in the list
+        echo "going to check the latest bundle image in the index image ..."
+        EXPORT_OUTPUT_FILE=${TEMP_DIR}/export-output
+        cd ${TEMP_DIR}
+            opm index export --index=${FROM_INDEX_IMAGE} -c=${IMAGE_BUILDER} -o=${OPERATOR_NAME} >${EXPORT_OUTPUT_FILE} 2>&1 &
+        cd ${CURRENT_DIR}
+        # read the file containing the output and check if it contains "Preparing to pull bundles" clause. The timeout is 1 minute
+        LAST_VERSION_IN_INDEX=""
+        while [[ -z ${LAST_VERSION_IN_INDEX} ]] && [[ ${NEXT_WAIT_TIME} -lt 60 ]]; do
+            # if the output contains "Preparing to pull bundles" clause then pick the first bundle image and take only the version suffix
+            # ie. from:
+            #     ... Preparing to pull bundles [\"quay.io/matousjobanek/host-operator-bundle:0.0.217-105-commit-25cbcfd-64af1be\" \"quay.io ...
+            # take only 0.0.217-105-commit-25cbcfd-64af1be
+            LAST_VERSION_IN_INDEX=$(grep "Preparing to pull bundles" ${EXPORT_OUTPUT_FILE} | sed 's/.*\\"\(.*\)\\"}].*/\1/')
+            echo "$(( NEXT_WAIT_TIME++ )). attempt of waiting for the latest bundle image in the index"
+            sleep 1
+        done
+        # kill the opm index export process
+        echo "the wait finished - killing the opm process"
+        kill %1 || true
+
+        # check if the latest bundle image version was found or not
+        if [[ -n ${LAST_VERSION_IN_INDEX} ]]; then
+            echo "latest bundle image version in index was found: ${LAST_VERSION_IN_INDEX}"
+
+            # if it was found then compare if the expected replace version is the same as the latest one
+            if [[ ${REPLACE_VERSION_SUFFIX} != ${LAST_VERSION_IN_INDEX} ]]; then
+                echo "the replaces version \"${REPLACE_VERSION_SUFFIX}\" is NOT the same as the latest version in index \"${LAST_VERSION_IN_INDEX}\""
+
+                # if the expected replace version is not the same as the latest one then let's check if new version that is going to be added is same as the latest one
+                # if it is, then it means that the bundle image with that version was already added
+                if [[ ${CURRENT_VERSION} != ${LAST_VERSION_IN_INDEX} ]]; then
+                    echo "the next new version \"${CURRENT_VERSION}\" is NOT the same as the latest version in index \"${LAST_VERSION_IN_INDEX}\""
+
+                    # if it's not the same, then it means that there is some version missing
+                    # in this "if" statement we check if the latest image version has something in common with the one in "replaces" clause
+                    if [[ -n $(echo ${LAST_VERSION_IN_INDEX} | grep "${SPLIT_REPLACE_VERSION[0]}-[0-9]*-commit-${SPLIT_REPLACE_VERSION[3]}.*") ]] || \
+                    [[ -n $(echo ${LAST_VERSION_IN_INDEX} | grep "0.0.[0-9]*-${SPLIT_REPLACE_VERSION[1]}-commit-[^-]*-${SPLIT_REPLACE_VERSION[4]}") ]]; then
+                        echo "we found something in common with the latest bundle image version in the index, so we will use the version \"${LAST_VERSION_IN_INDEX}\" for the replacement"
+
+                        # if it has something in common then it would mean that there is most like only one version missing
+                        # in that case let's replace the "replaces" clause with the latest image version and use that one
+                        TEMP_CSV_REPLACE="${TEMP_DIR}/${PRJ_NAME}_${CURRENT_VERSION}_csv_replace.yaml"
+                        sed "s/replaces: ${REPLACE_VERSION}$/replaces: ${OPERATOR_NAME}.v${LAST_VERSION_IN_INDEX}/" ${CSV_LOCATION} > ${TEMP_CSV_REPLACE}
+                        mv ${TEMP_CSV_REPLACE} ${CSV_LOCATION}
+                    else
+                        echo "we didn't find anything in common in the the latest bundle image version, but we will continue and hope that it will magically work"
+                    fi
+                else
+                    echo "the next new version \"${CURRENT_VERSION}\" IS the same as the latest version in index \"${LAST_VERSION_IN_INDEX}\""
+                    echo "this means that the version has been already added to the index"
+                    echo "exiting the CD process..."
+                    exit 0
+                fi
+             else
+                echo "the replaces version \"${REPLACE_VERSION_SUFFIX}\" IS the same as the latest version in index \"${LAST_VERSION_IN_INDEX}\""
+                echo "that means that no version is missing in the index"
+             fi
+        else
+            echo "the latest bundle image wasn't found in the opm output - we will continue and hope that everything will work fine"
+            echo "see the opm output:"
+            cat ${EXPORT_OUTPUT_FILE}
+        fi
+    else
+        echo "the split replace version doesn't have 5 parts (${SPLIT_REPLACE_VERSION[@]}) so it means that it's not a combined operator (host-operator + registration-service)"
+    fi
+}
+
+# use the olm-setup as the source
+OLM_SETUP_FILE=scripts/cd/olm-setup.sh
+OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
+
+if [[ -f ${OLM_SETUP_FILE} ]]; then
+    source ${OLM_SETUP_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}/${OLM_SETUP_FILE})"
+    fi
+fi
+
+# read argument to get project root dir
+read_arguments $@
+
+# if the main repo is specified then reconfigure the variables so the project root points to the temp directory
+if [[ -n "${MAIN_REPO_URL}"  ]]; then
+    REPO_NAME_WITH_GIT=$(basename $(echo ${MAIN_REPO_URL}))
+    OTHER_REPO_PATH=${OTHER_REPO_ROOT_DIR}/${REPO_NAME_WITH_GIT%.*}
+    read_arguments $@ -pr ${OTHER_REPO_PATH}
+fi
+
+# retrieve the current version
+CSV_LOCATION="${MANIFESTS_DIR}/*clusterserviceversion.yaml"
+CURRENT_VERSION=`grep "^  version: " ${CSV_LOCATION} | awk '{print $2}'`
+
+# set the image names variables
+BUNDLE_IMAGE=quay.io/${QUAY_NAMESPACE_TO_PUSH}/${PRJ_NAME}-bundle:${BUNDLE_TAG:-${CURRENT_VERSION}}
+INDEX_IMAGE=quay.io/${QUAY_NAMESPACE_TO_PUSH}/${INDEX_IMAGE_NAME}:latest
+FROM_INDEX_IMAGE="${INDEX_IMAGE}"
+
+if [[ -n "${INDEX_IMAGE_TAG}" ]]; then
+    INDEX_IMAGE=quay.io/${QUAY_NAMESPACE_TO_PUSH}/${INDEX_IMAGE_NAME}:${INDEX_IMAGE_TAG}
+fi
+
+# get the current version that is in the "replaces" clause of the CSV
+REPLACE_VERSION=`grep "^  replaces: " ${CSV_LOCATION} | awk '{print $2}'`
+if [[ -n ${REPLACE_VERSION} ]]; then
+    # get only the suffix from the replace version (ie. from toolchain-host-operator.v0.0.217-105-commit-6c9926d-64af1be get only 0.0.217-105-commit-6c9926d-64af1be)
+    REPLACE_VERSION_SUFFIX=`echo ${REPLACE_VERSION} | sed -e "s/^.*operator.v//"`
+
+    handle_missing_version_in_combined_repo
+else
+    FROM_INDEX_IMAGE=""
+fi
+
+cd ${PRJ_ROOT_DIR}
+
+echo "building & pushing operator bundle image ${BUNDLE_IMAGE}..."
+${IMAGE_BUILDER} build -f bundle.Dockerfile -t ${BUNDLE_IMAGE} .
+${IMAGE_BUILDER} push ${BUNDLE_IMAGE}
+
+if [[ ${IMAGE_BUILDER} == "podman" ]]; then
+    PULL_TOOL_PARAM="--pull-tool podman"
+fi
+
+
+if [[ -z ${GITHUB_ACTIONS} ]]; then
+    ${IMAGE_BUILDER} image rm quay.io/operator-framework/upstream-opm-builder:latest || true
+fi
+
+echo "modifying & pushing operator index image ${INDEX_IMAGE}..."
+if [[ -n ${FROM_INDEX_IMAGE} ]] && [[ `${IMAGE_BUILDER} pull ${FROM_INDEX_IMAGE}` ]]; then
+    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} --from-index ${FROM_INDEX_IMAGE} ${PULL_TOOL_PARAM}
+else
+    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} ${PULL_TOOL_PARAM}
+fi
+
+${IMAGE_BUILDER} push ${INDEX_IMAGE}
+
+cd ${CURRENT_DIR}

--- a/scripts/ci/manage-host-operator.sh
+++ b/scripts/ci/manage-host-operator.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -ex
+
+MANAGE_OPERATOR_FILE=scripts/ci/manage-operator.sh
+OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
+
+if [[ -f ${MANAGE_OPERATOR_FILE} ]]; then
+    source ${MANAGE_OPERATOR_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${MANAGE_OPERATOR_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${MANAGE_OPERATOR_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}/${MANAGE_OPERATOR_FILE})"
+    fi
+fi
+
+REPOSITORY_NAME=registration-service
+PROVIDED_REPOSITORY_PATH=${REG_REPO_PATH}
+get_repo
+set_tags
+
+if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
+    push_image
+    REG_SERV_IMAGE_LOC=${IMAGE_LOC}
+    REG_REPO_PATH=${REPOSITORY_PATH}
+fi
+
+
+REPOSITORY_NAME=host-operator
+PROVIDED_REPOSITORY_PATH=${HOST_REPO_PATH}
+get_repo
+set_tags
+
+# can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
+# if [[ ${PUBLISH_OPERATOR} == "true" ]] && [[ -n ${BUNDLE_AND_INDEX_TAG} ]]; then
+if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
+    push_image
+    OPERATOR_IMAGE_LOC=${IMAGE_LOC}
+    make -C ${REPOSITORY_PATH} publish-current-bundle ENV=${ENVIRONMENT} INDEX_IMAGE_TAG=${BUNDLE_AND_INDEX_TAG} BUNDLE_TAG=${BUNDLE_AND_INDEX_TAG} QUAY_NAMESPACE=${QUAY_NAMESPACE} OTHER_REPO_PATH=${REG_REPO_PATH} OTHER_REPO_IMAGE_LOC=${REG_SERV_IMAGE_LOC} IMAGE=${OPERATOR_IMAGE_LOC}
+fi
+
+if [[ ${INSTALL_OPERATOR} == "true" ]]; then
+#    can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
+#    if [[ -z ${BUNDLE_AND_INDEX_TAG} ]]; then
+#        BUNDLE_AND_INDEX_TAG=latest
+#        QUAY_NAMESPACE=codeready-toolchain
+#    fi
+
+    OPERATOR_NAME=toolchain-host-operator
+    INDEX_IMAGE_NAME=host-operator-index
+    NAMESPACE=${HOST_NS}
+    EXPECT_CRD=toolchainconfigs.toolchain.dev.openshift.com
+    install_operator
+fi

--- a/scripts/ci/manage-member-operator.sh
+++ b/scripts/ci/manage-member-operator.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -ex
+
+MANAGE_OPERATOR_FILE=scripts/ci/manage-operator.sh
+OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
+
+if [[ -f ${MANAGE_OPERATOR_FILE} ]]; then
+    source ${MANAGE_OPERATOR_FILE}
+else
+    if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${MANAGE_OPERATOR_FILE} ]]; then
+        source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${MANAGE_OPERATOR_FILE}
+    else
+        source /dev/stdin <<< "$(curl -sSL https://raw.githubusercontent.com/${OWNER_AND_BRANCH_LOCATION}/${MANAGE_OPERATOR_FILE})"
+    fi
+fi
+
+REPOSITORY_NAME=member-operator
+PROVIDED_REPOSITORY_PATH=${MEMBER_REPO_PATH}
+get_repo
+set_tags
+
+# can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
+#if [[ ${PUBLISH_OPERATOR} == "true" ]] && [[ -n ${BUNDLE_AND_INDEX_TAG} ]]; then
+if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
+    push_image
+
+    OPERATOR_IMAGE_LOC=${IMAGE_LOC}
+    COMPONENT_IMAGE_LOC=$(echo ${IMAGE_LOC} | sed 's/\/member-operator/\/member-operator-webhook/')
+
+    make -C ${REPOSITORY_PATH} publish-current-bundle ENV=${ENVIRONMENT} INDEX_IMAGE_TAG=${BUNDLE_AND_INDEX_TAG} BUNDLE_TAG=${BUNDLE_AND_INDEX_TAG} QUAY_NAMESPACE=${QUAY_NAMESPACE} COMPONENT_IMAGE=${COMPONENT_IMAGE_LOC} IMAGE=${OPERATOR_IMAGE_LOC}
+fi
+
+if [[ ${INSTALL_OPERATOR} == "true" ]]; then
+#    can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
+#    if [[ -z ${BUNDLE_AND_INDEX_TAG} ]]; then
+#        BUNDLE_AND_INDEX_TAG=latest
+#        QUAY_NAMESPACE=codeready-toolchain
+#    fi
+
+    OPERATOR_NAME=toolchain-member-operator
+    INDEX_IMAGE_NAME=member-operator-index
+    NAMESPACE=${MEMBER_NS}
+    EXPECT_CRD=memberoperatorconfigs.toolchain.dev.openshift.com
+    install_operator
+    if [[ -n ${MEMBER_NS_2} ]]; then
+        NAMESPACE=${MEMBER_NS_2}
+        install_operator
+    fi
+fi

--- a/scripts/ci/manage-operator.sh
+++ b/scripts/ci/manage-operator.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+set -ex
+
+WAS_ALREADY_PAIRED_FILE=/tmp/toolchain_e2e_already_paired
+
+get_repo() {
+    PAIRED=false
+    if [[ -z ${PROVIDED_REPOSITORY_PATH} ]]; then
+        REPOSITORY_PATH="/tmp/codeready-toolchain/${REPOSITORY_NAME}"
+        rm -rf ${REPOSITORY_PATH}
+        # clone
+        git clone https://github.com/codeready-toolchain/${REPOSITORY_NAME}.git ${REPOSITORY_PATH}
+
+        pair_repo_if_needed
+    else
+        REPOSITORY_PATH=${PROVIDED_REPOSITORY_PATH}
+    fi
+
+}
+
+set_tags() {
+    TAGS=${DATE_SUFFIX}
+    COMMIT_ID_SUFFIX=${PULL_PULL_SHA:0:7}
+
+    if [[ -n "${CI}${CLONEREFS_OPTIONS}" ]]; then
+        if [[ -n ${GITHUB_ACTIONS} ]]; then
+            OPERATOR_REPO_NAME=${GITHUB_REPOSITORY##*/}
+            TAGS=from.${OPERATOR_REPO_NAME}.PR${PULL_NUMBER}.${COMMIT_ID_SUFFIX}
+        else
+            AUTHOR=$(jq -r '.refs[0].pulls[0].author' <<< ${CLONEREFS_OPTIONS} | tr -d '[:space:]')
+            PULL_PULL_SHA=${PULL_PULL_SHA:-$(jq -r '.refs[0].pulls[0].sha' <<< ${CLONEREFS_OPTIONS} | tr -d '[:space:]')}
+            TAGS=from.${REPO_NAME}.PR${PULL_NUMBER}.${COMMIT_ID_SUFFIX}
+        fi
+    fi
+#    can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
+#    if is_provided_or_paired; then
+        BUNDLE_AND_INDEX_TAG=${TAGS}
+#    fi
+}
+
+push_image() {
+    GIT_COMMIT_ID=$(git --git-dir=${REPOSITORY_PATH}/.git --work-tree=${REPOSITORY_PATH} rev-parse --short HEAD)
+    IMAGE_LOC=quay.io/codeready-toolchain/${REPOSITORY_NAME}:${GIT_COMMIT_ID}
+    if is_provided_or_paired; then
+        make -C ${REPOSITORY_PATH} docker-push QUAY_NAMESPACE=${QUAY_NAMESPACE} IMAGE_TAG=${TAGS}
+        IMAGE_LOC=quay.io/${QUAY_NAMESPACE}/${REPOSITORY_NAME}:${TAGS}
+    fi
+}
+
+is_provided_or_paired() {
+    [[ -n ${PROVIDED_REPOSITORY_PATH} ]] || [[ ${PAIRED} == true ]]
+}
+
+pair_repo_if_needed() {
+    if [[ -n ${GITHUB_ACTIONS} ]]; then
+        PR_REPO_NAME=${GITHUB_REPOSITORY##*/}
+    else
+        PR_REPO_NAME=${REPO_NAME}
+    fi
+
+
+    if [[ -n "${CI}${CLONEREFS_OPTIONS}" ]] && [[ ${PR_REPO_NAME} == "toolchain-e2e" ]]; then
+        if [[ -n ${CLONEREFS_OPTIONS} ]]; then
+            # get branch ref of the fork the PR was created from
+            AUTHOR_LINK=$(jq -r '.refs[0].pulls[0].author_link' <<< ${CLONEREFS_OPTIONS} | tr -d '[:space:]')
+            PULL_PULL_SHA=${PULL_PULL_SHA:-$(jq -r '.refs[0].pulls[0].sha' <<< ${CLONEREFS_OPTIONS} | tr -d '[:space:]')}
+            echo "using author link ${AUTHOR_LINK}"
+            echo "using pull sha ${PULL_PULL_SHA}"
+            # get branch ref of the fork the PR was created from
+            REPO_URL=${AUTHOR_LINK}/toolchain-e2e
+            echo "branches of ${REPO_URL} - trying to detect the branch name we should use for pairing."
+            curl ${REPO_URL}.git/info/refs?service=git-upload-pack --output -
+            GET_BRANCH_NAME=$(curl ${REPO_URL}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a ${PULL_PULL_SHA} || true)
+            if [[ $(echo ${GET_BRANCH_NAME} | wc -l) > 1 ]]; then \
+                echo "###################################  ERROR DURING THE E2E TEST SETUP  ###################################
+There were found more branches with the same latest commit '${PULL_PULL_SHA}' in the repo ${REPO_URL} - see:
+
+${GET_BRANCH_NAME}
+
+It's not possible to detect the correct branch this PR is made for.
+Please delete the unrelated branch from your fork and rerun the e2e tests.
+Note: If you have already deleted the unrelated branch from your fork, it can take a few hours before the
+      github api is updated so the e2e tests may still fail with the same error until then.
+##########################################################################################################"
+                exit 1
+            fi
+            BRANCH_REF=$(echo ${GET_BRANCH_NAME} | awk '{print $2}')
+            echo "detected branch ref ${BRANCH_REF}"
+            # retrieve the branch name
+            BRANCH_NAME=$(echo ${BRANCH_REF} | awk -F'/' '{print $3}')
+        else
+            AUTHOR_LINK=https://github.com/${AUTHOR}
+            BRANCH_REF=refs/heads/${GITHUB_HEAD_REF}
+            BRANCH_NAME=${GITHUB_HEAD_REF}
+            REPO_URL=${AUTHOR_LINK}/toolchain-e2e
+        fi
+
+        if [[ -n "${BRANCH_REF}" ]]; then \
+            # check if a branch with the same ref exists in the user's fork of ${REPOSITORY_NAME} repo
+            echo "branches of ${AUTHOR_LINK}/${REPOSITORY_NAME} - checking if there is a branch ${BRANCH_REF} we could pair with."
+            curl ${AUTHOR_LINK}/${REPOSITORY_NAME}.git/info/refs?service=git-upload-pack --output -
+            REMOTE_E2E_BRANCH=$(curl ${AUTHOR_LINK}/${REPOSITORY_NAME}.git/info/refs?service=git-upload-pack --output - 2>/dev/null | grep -a "${BRANCH_REF}$" | awk '{print $2}')
+            echo "branch ref of the user's fork: \"${REMOTE_E2E_BRANCH}\" - if empty then not found"
+            # check if the branch with the same name exists, if so then merge it with master and use the merge branch, if not then use master \
+            if [[ -n "${REMOTE_E2E_BRANCH}" ]]; then \
+                if [[ -f ${WAS_ALREADY_PAIRED_FILE} ]]; then \
+                    echo "####################################  ERROR WHILE TRYING TO PAIR PRs  ####################################
+There was an error while trying to pair this e2e PR with ${AUTHOR_LINK}/${REPOSITORY_NAME}@${BRANCH_REF}
+The reason is that there was already detected a branch from another repo this PR could be paired with - see:
+
+$(cat ${WAS_ALREADY_PAIRED_FILE})
+
+It's not possible to pair a PR with multiple branches from other repositories.
+Please delete one of the branches from your fork and rerun the e2e tests
+Note: If you have already deleted one of the branches from your fork, it can take a few hours before the
+      github api is updated so the e2e tests may still fail with the same error until then.
+##########################################################################################################"
+                    exit 1
+                fi
+
+                git config --global user.email "devtools@redhat.com"
+                git config --global user.name "Devtools"
+
+                echo -e "repository: ${AUTHOR_LINK}/${REPOSITORY_NAME} \nbranch: ${BRANCH_NAME}" > ${WAS_ALREADY_PAIRED_FILE}
+                # add the user's fork as remote repo
+                git --git-dir=${REPOSITORY_PATH}/.git --work-tree=${REPOSITORY_PATH} remote add external ${AUTHOR_LINK}/${REPOSITORY_NAME}.git
+                # fetch the branch
+                git --git-dir=${REPOSITORY_PATH}/.git --work-tree=${REPOSITORY_PATH} fetch external ${BRANCH_REF}
+                # merge the branch with master
+                git --git-dir=${REPOSITORY_PATH}/.git --work-tree=${REPOSITORY_PATH} merge --allow-unrelated-histories --no-commit FETCH_HEAD
+
+                PAIRED=true
+            fi
+        fi
+    fi
+}
+
+
+install_operator() {
+    DISPLAYNAME=$(echo ${OPERATOR_NAME} | tr '-' ' ' | awk '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1')
+
+    GIT_COMMIT_ID=`git --git-dir=${REPOSITORY_PATH}/.git --work-tree=${REPOSITORY_PATH} rev-parse --short HEAD`
+    INDEX_IMAGE=quay.io/${QUAY_NAMESPACE}/${INDEX_IMAGE_NAME}:${BUNDLE_AND_INDEX_TAG}
+    CATALOGSOURCE_NAME=source-${OPERATOR_NAME}-${GIT_COMMIT_ID}
+    SUBSCRIPTION_NAME=subscription-${OPERATOR_NAME}-${GIT_COMMIT_ID}
+    INSTALL_OBJECTS="apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og-${OPERATOR_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  targetNamespaces:
+  - ${NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ${SUBSCRIPTION_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  channel: ${CHANNEL}
+  installPlanApproval: Automatic
+  name: ${OPERATOR_NAME}
+  source: ${CATALOGSOURCE_NAME}
+  sourceNamespace: ${NAMESPACE}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ${CATALOGSOURCE_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  sourceType: grpc
+  image: ${INDEX_IMAGE}
+  displayName: ${DISPLAYNAME}
+  publisher: Red Hat
+  updateStrategy:
+    registryPoll:
+      interval: 1m0s"
+    echo "objects to be created in order to install operator"
+    cat <<EOF | oc apply -f -
+${INSTALL_OBJECTS}
+EOF
+
+wait_until_is_installed
+}
+
+wait_until_is_installed() {
+    set -e
+    NEXT_WAIT_TIME=0
+    while [[ -z `oc get crd | grep ${EXPECT_CRD} || true` ]]; do
+        if [[ ${NEXT_WAIT_TIME} -eq 100 ]]; then
+           echo "reached timeout of waiting for CRD ${EXPECT_CRD} to be available in the cluster - see following info for debugging:"
+           echo "================================ CatalogSource =================================="
+           oc get catalogsource ${CATALOGSOURCE_NAME} -n ${NAMESPACE} -o yaml
+           echo "================================ CatalogSource Pod Logs =================================="
+           oc logs `oc get pods -l "olm.catalogSource=${CATALOGSOURCE_NAME#*/}" -n ${NAMESPACE} -o name` -n ${NAMESPACE}
+           echo "================================ Subscription =================================="
+           oc get subscription ${SUBSCRIPTION_NAME} -n ${NAMESPACE} -o yaml
+           echo "================================ InstallPlans =================================="
+           oc get installplans -n ${NAMESPACE} -o yaml
+           exit 1
+        fi
+        echo "$(( NEXT_WAIT_TIME++ )). attempt of waiting for CRD ${EXPECT_CRD} to be available in the cluster"
+        sleep 1
+    done
+}


### PR DESCRIPTION
copies all scripts from other repositories:
* api
* toolchain-common
* toolchain-e2e

so it's all in one repo and it's easier to manage.
It also slightly changes the way it installs the operator.

In the following PRs I will:
* redirect all logic to use this new location
* remove the scripts from the other repositories