### PR TITLE
fix: use hard-coded channel name

### DIFF
--- a/scripts/ci/manage-operator.sh
+++ b/scripts/ci/manage-operator.sh
@@ -159,7 +159,7 @@ metadata:
   name: ${SUBSCRIPTION_NAME}
   namespace: ${NAMESPACE}
 spec:
-  channel: ${CHANNEL}
+  channel: alpha
   installPlanApproval: Automatic
   name: ${OPERATOR_NAME}
   source: ${CATALOGSOURCE_NAME}


### PR DESCRIPTION
for this type of use-cases we don't need a dynamic channel name - let's just hard-code it to `alpha` 