### PR TITLE
feat: support deploying latest versions from quay

### DIFF
--- a/scripts/ci/manage-host-operator.sh
+++ b/scripts/ci/manage-host-operator.sh
@@ -10,6 +10,7 @@ user_help () {
     echo "-hr, --host-repo-path    Path to the host operator repo"
     echo "-rr, --reg-repo-path     Path to the registation service repo"
     echo "-ds, --date-suffix       Date suffix to be added to some resources that are created"
+    echo "-dl, --deploy-latest     Deploy the latest version of operator"
     echo "-h,  --help              To show this help text"
     echo ""
     exit 0
@@ -62,6 +63,11 @@ read_arguments() {
                     DATE_SUFFIX=$1
                     shift
                     ;;
+                -dl|--deploy-latest)
+                    shift
+                    DEPLOY_LATEST=$1
+                    shift
+                    ;;
                 *)
                    echo "$1 is not a recognized flag!" >> /dev/stderr
                    user_help
@@ -75,7 +81,11 @@ set -e
 
 read_arguments $@
 
-set -ex
+if [[ -n "${CI}" ]]; then
+    set -ex
+else
+    set -e
+fi
 
 MANAGE_OPERATOR_FILE=scripts/ci/manage-operator.sh
 OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
@@ -90,38 +100,34 @@ else
     fi
 fi
 
-REPOSITORY_NAME=registration-service
-PROVIDED_REPOSITORY_PATH=${REG_REPO_PATH}
-get_repo
-set_tags
+if [[ DEPLOY_LATEST != "true" ]] && [[ -n "${CI}${REG_REPO_PATH}${HOST_REPO_PATH}" ]]; then
+    REPOSITORY_NAME=registration-service
+    PROVIDED_REPOSITORY_PATH=${REG_REPO_PATH}
+    get_repo
+    set_tags
 
-if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
-    push_image
-    REG_SERV_IMAGE_LOC=${IMAGE_LOC}
-    REG_REPO_PATH=${REPOSITORY_PATH}
-fi
+    if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
+        push_image
+        REG_SERV_IMAGE_LOC=${IMAGE_LOC}
+        REG_REPO_PATH=${REPOSITORY_PATH}
+    fi
 
 
-REPOSITORY_NAME=host-operator
-PROVIDED_REPOSITORY_PATH=${HOST_REPO_PATH}
-get_repo
-set_tags
+    REPOSITORY_NAME=host-operator
+    PROVIDED_REPOSITORY_PATH=${HOST_REPO_PATH}
+    get_repo
+    set_tags
 
-# can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
-# if [[ ${PUBLISH_OPERATOR} == "true" ]] && [[ -n ${BUNDLE_AND_INDEX_TAG} ]]; then
-if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
-    push_image
-    OPERATOR_IMAGE_LOC=${IMAGE_LOC}
-    make -C ${REPOSITORY_PATH} publish-current-bundle INDEX_IMAGE_TAG=${BUNDLE_AND_INDEX_TAG} BUNDLE_TAG=${BUNDLE_AND_INDEX_TAG} QUAY_NAMESPACE=${QUAY_NAMESPACE} OTHER_REPO_PATH=${REG_REPO_PATH} OTHER_REPO_IMAGE_LOC=${REG_SERV_IMAGE_LOC} IMAGE=${OPERATOR_IMAGE_LOC}
+    if [[ ${PUBLISH_OPERATOR} == "true" ]]; then
+        push_image
+        OPERATOR_IMAGE_LOC=${IMAGE_LOC}
+        make -C ${REPOSITORY_PATH} publish-current-bundle INDEX_IMAGE_TAG=${BUNDLE_AND_INDEX_TAG} BUNDLE_TAG=${BUNDLE_AND_INDEX_TAG} QUAY_NAMESPACE=${QUAY_NAMESPACE} OTHER_REPO_PATH=${REG_REPO_PATH} OTHER_REPO_IMAGE_LOC=${REG_SERV_IMAGE_LOC} IMAGE=${OPERATOR_IMAGE_LOC}
+    fi
+else
+    INDEX_IMAGE_LOC="quay.io/codeready-toolchain/host-operator-index:latest"
 fi
 
 if [[ ${INSTALL_OPERATOR} == "true" ]]; then
-#    can be used only when the operator CSV doesn't bundle the environment information, but now we want to build bundle for both operators
-#    if [[ -z ${BUNDLE_AND_INDEX_TAG} ]]; then
-#        BUNDLE_AND_INDEX_TAG=latest
-#        QUAY_NAMESPACE=codeready-toolchain
-#    fi
-
     OPERATOR_NAME=toolchain-host-operator
     INDEX_IMAGE_NAME=host-operator-index
     NAMESPACE=${HOST_NS}


### PR DESCRIPTION
This PR:
* adds support for installing the latest version from quay - without building the images from the GH repo. The latest version is used when:
    * either `--deploy-latest=true` flag is set 
    * or when it runs locally (`CI` var is not set) and the path to the operator directory is not provided - this means when it is not supposed to use the local copy o the operator repository (for example when running `make test-e2e`)
* enables the verbose output of the scripts only in CI  
* when it detects an already existing installation of any of the operators, then it waits until the installation is properly removed 

related PR: https://github.com/codeready-toolchain/toolchain-e2e/pull/443