### PR TITLE
workaround: increase wait timeout

### DIFF
--- a/scripts/ci/wait-until-is-installed.sh
+++ b/scripts/ci/wait-until-is-installed.sh
@@ -66,9 +66,17 @@ printAllPodLogsInNamespace() {
 wait_until_is_installed() {
     echo "Waiting for CRD ${EXPECT_CRD} to be available in the cluster..."
     OLM_NS="openshift-operator-lifecycle-manager"
+
     NEXT_WAIT_TIME=0
+    MAX_NUM_ATTEMPTS=100
+    SLEEP_TIME=1
+    if [[ -n "${CI}${CLONEREFS_OPTIONS}" ]]; then
+        MAX_NUM_ATTEMPTS=200
+        SLEEP_TIME=3
+    fi
+
     while [[ -z `oc get crd | grep ${EXPECT_CRD} || true` ]]; do
-        if [[ ${NEXT_WAIT_TIME} -eq 100 ]]; then
+        if [[ ${NEXT_WAIT_TIME} -eq ${MAX_NUM_ATTEMPTS} ]]; then
            echo "reached timeout of waiting for CRD ${EXPECT_CRD} to be available in the cluster - see following info for debugging:"
            echo "================================ CatalogSource =================================="
            oc get catalogsource ${CATALOGSOURCE_NAME} -n ${NAMESPACE} -o yaml
@@ -82,8 +90,8 @@ wait_until_is_installed() {
            printAllPodLogsInNamespace $NAMESPACE
            exit 1
         fi
-        echo "$(( NEXT_WAIT_TIME++ )). attempt (out of 100) of waiting for CRD ${EXPECT_CRD} to be available in the cluster"
-        sleep 1
+        echo "$(( NEXT_WAIT_TIME++ )). attempt (out of ${MAX_NUM_ATTEMPTS}) of waiting for CRD ${EXPECT_CRD} to be available in the cluster"
+        sleep ${SLEEP_TIME}
     done
 }
 


### PR DESCRIPTION
from the logs it looks like it has problems with connecting to quay repo:
```
I0319 02:23:40.617962       1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"", Name:"toolchain-host-19022157", UID:"1b9b3eb7-8a86-4859-9fc1-2056e7bf0e30", APIVersion:"v1", ResourceVersion:"29772", FieldPath:""}): type: 'Warning' reason: 'ResolutionFailed' error using catalog source-toolchain-host-operator-latest (in namespace toolchain-host-19022157): failed to list bundles: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp 172.30.202.37:50051: connect: no route to host"
```
can be either caused on OS side or on Quay side. 
Anyway, let's try to increase the timeout as a workaround