### PR TITLE
adapt cluster script to kube 1.24

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 user_help () {
     echo "Creates ToolchainCluster"

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -294,9 +294,9 @@ if [[ ${SERVER_VERSION} -gt 10 ]]; then
   # create a token with duration of 100 years
   SA_TOKEN=$(oc create token ${SA_NAME} --duration 876000h -n ${OPERATOR_NS} ${OC_ADDITIONAL_PARAMS})
 else
-  SA_SECRET=`oc get secrets -n ${OPERATOR_NS} -o name ${OC_ADDITIONAL_PARAMS} | grep -e "secret/^${SA_NAME}-dockercfg-[a-z0-9]+" | cut -d "/" -f2`
+  SA_SECRET=`oc get sa ${SA_NAME} -n ${OPERATOR_NS} -o json ${OC_ADDITIONAL_PARAMS} | jq -r .secrets[].name | grep token`
   echo "SA secret found: ${SA_SECRET}"
-  SA_TOKEN=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS}  -o json ${OC_ADDITIONAL_PARAMS} | jq -r .'metadata.annotations."openshift.io/token-secret.value"'`
+  SA_TOKEN=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS}  -o json ${OC_ADDITIONAL_PARAMS} | jq -r '.data["token"]' | base64 --decode`
 fi
 echo "SA token retrieved"
 if [[ ${LETS_ENCRYPT} == "true" ]]; then

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 user_help () {
     echo "Creates ToolchainCluster"


### PR DESCRIPTION
if the cluster is running kube 1.24 or newer, then it creates a token via `kubectl create token` command. 
it also takes the client certificate from the kubeconfig

Please, do not merge this yet - requires additional testing and one more change in toolchain-common repo