### PR TITLE
fix: use latest in openshift/release jobs

### DIFF
--- a/scripts/ci/manage-host-operator.sh
+++ b/scripts/ci/manage-host-operator.sh
@@ -100,7 +100,7 @@ else
     fi
 fi
 
-if [[ ${DEPLOY_LATEST} != "true" ]] && [[ -n "${CI}${REG_REPO_PATH}${HOST_REPO_PATH}" ]]; then
+if [[ ${DEPLOY_LATEST} != "true" ]] && [[ -n "${CI}${REG_REPO_PATH}${HOST_REPO_PATH}" ]] && [[ ${REPO_NAME} != "release" ]]; then
     REPOSITORY_NAME=registration-service
     PROVIDED_REPOSITORY_PATH=${REG_REPO_PATH}
     get_repo

--- a/scripts/ci/manage-member-operator.sh
+++ b/scripts/ci/manage-member-operator.sh
@@ -99,7 +99,7 @@ else
     fi
 fi
 
-if [[ ${DEPLOY_LATEST} != "true" ]] && [[ -n "${CI}${MEMBER_REPO_PATH}" ]]; then
+if [[ ${DEPLOY_LATEST} != "true" ]] && [[ -n "${CI}${MEMBER_REPO_PATH}" ]] && [[ ${REPO_NAME} != "release" ]]; then
     REPOSITORY_NAME=member-operator
     PROVIDED_REPOSITORY_PATH=${MEMBER_REPO_PATH}
     get_repo


### PR DESCRIPTION
When the builds are running as part of the openshift/release jobs, then we should always use the latest version of the operators