### PR TITLE
add `--image-platform` parameter to support cross-platform docker ima…

### DIFF
--- a/scripts/cd/generate-cd-release-manifests.sh
+++ b/scripts/cd/generate-cd-release-manifests.sh
@@ -4,11 +4,13 @@
 # this way the source of the local file can work independently of where the script is executed from.
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # use the olm-setup as the source
-OLM_SETUP_FILE=${SCRIPT_DIR}/olm-setup.sh
+OLM_SETUP_FILE=scripts/cd/olm-setup.sh
+LOCAL_OLM_SETUP_FILE=${SCRIPT_DIR}/olm-setup.sh
 OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
 
-if [[ -f ${OLM_SETUP_FILE} ]]; then
-    source ${OLM_SETUP_FILE}
+if [[ -f ${LOCAL_OLM_SETUP_FILE} ]]; then
+    echo "sourcing local olm setup file ${LOCAL_OLM_SETUP_FILE}"
+    source ${LOCAL_OLM_SETUP_FILE}
 else
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE}

--- a/scripts/cd/generate-cd-release-manifests.sh
+++ b/scripts/cd/generate-cd-release-manifests.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# get abs path of the directory where this script is located
+# this way the source of the local file can work independently of where the script is executed from.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # use the olm-setup as the source
-OLM_SETUP_FILE=scripts/cd/olm-setup.sh
+OLM_SETUP_FILE=${SCRIPT_DIR}/olm-setup.sh
 OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
 
 if [[ -f ${OLM_SETUP_FILE} ]]; then

--- a/scripts/cd/olm-setup.sh
+++ b/scripts/cd/olm-setup.sh
@@ -24,6 +24,7 @@ user_help () {
     echo "-bt, --bundle-tag        Tag of the bundle image."
     echo "-fr, --first-release     If set to true, then it will generate CSV without replaces clause."
     echo "-ci, --component-image   The name of the image to be used as a component of this operator."
+    echo "-ip, --image-platform    The platform for which the image should be built (default: linux/amd64)."
     echo "-h,  --help              To show this help text"
     echo ""
     additional_help 2>/dev/null || true
@@ -131,6 +132,11 @@ read_arguments() {
                     COMPONENT_IMAGE=$1
                     shift
                     ;;
+                -ip|--image-platform)
+                    shift
+                    IMAGE_PLATFORM=$1
+                    shift
+                    ;;
                 *)
                    echo "$1 is not a recognized flag!" >> /dev/stderr
                    user_help
@@ -181,6 +187,8 @@ setup_variables() {
 
     # Image builder
     IMAGE_BUILDER=${IMAGE_BUILDER:-"docker"}
+    # set default image platform when not provided
+    IMAGE_PLATFORM="${IMAGE_PLATFORM:-"linux/amd64"}"
 
     # Files and directories related vars
     PRJ_NAME=`basename ${PRJ_ROOT_DIR}`

--- a/scripts/cd/push-bundle-and-index-image.sh
+++ b/scripts/cd/push-bundle-and-index-image.sh
@@ -76,13 +76,18 @@ handle_missing_version_in_combined_repo() {
     fi
 }
 
+# get abs path of the directory where this script is located
+# this way the source of the local file can work independently of where the script is executed from.
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # use the olm-setup as the source
-OLM_SETUP_FILE=scripts/cd/olm-setup.sh
+OLM_SETUP_FILE=${SCRIPT_DIR}/olm-setup.sh
 OWNER_AND_BRANCH_LOCATION=${OWNER_AND_BRANCH_LOCATION:-codeready-toolchain/toolchain-cicd/master}
 
 if [[ -f ${OLM_SETUP_FILE} ]]; then
+    echo "sourcing local olm setup file ${OLM_SETUP_FILE}"
     source ${OLM_SETUP_FILE}
 else
+    echo "sourcing remote olm setup file"
     if [[ -f ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE} ]]; then
         source ${GOPATH}/src/github.com/codeready-toolchain/toolchain-cicd/${OLM_SETUP_FILE}
     else
@@ -127,7 +132,8 @@ fi
 cd ${PRJ_ROOT_DIR}
 
 echo "building & pushing operator bundle image ${BUNDLE_IMAGE}..."
-${IMAGE_BUILDER} build -f bundle.Dockerfile -t ${BUNDLE_IMAGE} .
+
+${IMAGE_BUILDER} build --platform ${IMAGE_PLATFORM} -f bundle.Dockerfile -t ${BUNDLE_IMAGE} .
 ${IMAGE_BUILDER} push ${BUNDLE_IMAGE}
 
 if [[ ${IMAGE_BUILDER} == "podman" ]]; then
@@ -141,11 +147,12 @@ fi
 
 echo "modifying & pushing operator index image ${INDEX_IMAGE}..."
 if [[ -n ${FROM_INDEX_IMAGE} ]] && [[ `${IMAGE_BUILDER} pull ${FROM_INDEX_IMAGE}` ]]; then
-    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} --from-index ${FROM_INDEX_IMAGE} ${PULL_TOOL_PARAM}
+    opm index add --generate --out-dockerfile index.Dockerfile --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} --from-index ${FROM_INDEX_IMAGE} ${PULL_TOOL_PARAM}
 else
-    opm index add --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} ${PULL_TOOL_PARAM}
+    opm index add --generate --out-dockerfile index.Dockerfile --bundles ${BUNDLE_IMAGE} --build-tool ${IMAGE_BUILDER} --tag ${INDEX_IMAGE} ${PULL_TOOL_PARAM}
 fi
 
+${IMAGE_BUILDER} build -f ./index.Dockerfile --platform ${IMAGE_PLATFORM} -t ${INDEX_IMAGE} .
 ${IMAGE_BUILDER} push ${INDEX_IMAGE}
 
 cd ${CURRENT_DIR}


### PR DESCRIPTION
While building docker images on Mac M1 chipset and deploying to AWS dev environment (running on linux/amd64) I need to change the build platform from my default one.

This PR enables configuring the docker build `platform` option, plus one minor fix where the olm-setup.sh was always sourced from remotely when tests were executed from inside the toolchain-e2e local directory.