### PR TITLE
PLNSRVCE-1166: add get route perms for toolchaincluster-member

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -120,6 +120,14 @@ rules:
   - "spacerequests"
   verbs:
   - "*"
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
to address this issue seen during local e2e testing:

`{"level":"info","ts":"2023-03-10T15:17:21.459Z","logger":"registration-service","msg":"GGM accessForSpace error routes.route.openshift.io \"member-operator-metrics-service\" is forbidden: User \"system:serviceaccount:toolchain-member-10100902:toolchaincluster-member\" cannot get resource \"routes\" in API group \"route.openshift.io\" in the namespace \"toolchain-member-10100902\"","timestamp":"Fri, 10 Mar 2023 15:17:21 +0000","commit":"32ff890"}`

upon revisiting https://github.com/codeready-toolchain/toolchain-common/pull/303 and seeing the existing presence of authenticationv1 there and the comment around verifying cached tokens, adding permissions here seems to line up with the existing permissions for creating tokenreviews in this same clusterrole, and the toolchaincluster-member cluster roles I discovered on my test system.

I was able to access my local copy of toolchains-cicd when running e2e's locally and verify this addresses the RBAC issue ^^

/assign @alexeykazakov 
/assign @rajivnathan 