### PR TITLE
fix: Failed to watch *v1.Namespace: unknown (get namespaces)

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -149,6 +149,7 @@ rules:
   verbs:
   - "get"
   - "list"
+  - "watch"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
fix issue caused by SpaceRequest controller when listing namespaces, seems that the client-go library needs watch permissions as well. Tested locally and the error goes away:

```
{"level":"error","ts":"2023-04-27T18:37:42.244Z","msg":"pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:169: Failed to watch *v1.Namespace: unknown (get namespaces)\n","stacktrace":"k8s.io/client-go/tools/cache.DefaultWatchErrorHandler\n\t/tmp/go/pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:140\nk8s.io/client-go/tools/cache.(*Reflector).Run.func1\n\t/tmp/go/pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:224\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:157\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:158\nk8s.io/client-go/tools/cache.(*Reflector).Run\n\t/tmp/go/pkg/mod/k8s.io/client-go@v0.25.0/tools/cache/reflector.go:222\nk8s.io/apimachinery/pkg/util/wait.(*Group).StartWithChannel.func1\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:58\nk8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1\n\t/tmp/go/pkg/mod/k8s.io/apimachinery@v0.25.0/pkg/util/wait/wait.go:75"}
```

Related PR:
- sandbox-sre: https://github.com/codeready-toolchain/sandbox-sre/pull/1004