### PR TITLE
KSPACE-28: Add spaceprovisionerconfigs to the host operator's role.

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -71,6 +71,7 @@ rules:
   - "usersignups"
   - "usertiers"
   - "proxyplugins"
+  - "spaceprovisionerconfigs"
   verbs:
   - "*"
 EOF


### PR DESCRIPTION
`$TITLE`.
This is in support for https://github.com/codeready-toolchain/api/pull/397