### PR TITLE
KUBESAW-45: Drop Toolchain Cluster CR type label

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -355,7 +355,6 @@ metadata:
   name: ${TOOLCHAINCLUSTER_NAME}
   namespace: ${CLUSTER_JOIN_TO_OPERATOR_NS}
   labels:
-    type: ${JOINING_CLUSTER_TYPE}
     namespace: ${OPERATOR_NS}
     ownerClusterName: obsolete
     ${CLUSTER_LABEL}


### PR DESCRIPTION
This is Related to https://github.com/codeready-toolchain/toolchain-common/pull/359 ,
Drop the distinction between host & member ToolchainClusters