### PR TITLE
KUBESAW-16: Label the secrets with the access tokens for toolchain clusters

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -338,6 +338,10 @@ fi
 # result is TOOLCHAINCLUSTER_NAME=a67d9ea16fe1a48dfbfd0526b33ac00c-279e3fade0dc0068.elb.us-east-1
 TOOLCHAINCLUSTER_NAME="${JOINING_CLUSTER_TYPE}-${JOINING_CLUSTER_NAME:0:CLUSTERNAME_LENGTH_TO_KEEP}${MULTI_MEMBER}"
 
+# We need to label the secret with the SA token with the toolchain cluster name so that in the future we can flip the dependency and create
+# the toolchain cluster based on the existence of the label.
+oc label secret ${SECRET_NAME} -n ${CLUSTER_JOIN_TO_OPERATOR_NS} ${OC_ADDITIONAL_PARAMS} "toolchain.dev.openshift.com/toolchain-cluster=${TOOLCHAINCLUSTER_NAME}"
+
 CLUSTER_JOIN_TO_TYPE_NAME=CLUSTER_JOIN_TO
 if [[ ${CLUSTER_JOIN_TO_TYPE_NAME} != "host" ]]; then
     CLUSTER_JOIN_TO_TYPE_NAME="member"


### PR DESCRIPTION
This updates the `add-cluster.sh` to put a label on the secret linked to the ToolchainCluster that marks the secret as belonging to the ToolchainCluster.

This is currently not really used for anything but will be used in the future.

Associated PRs:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/396
- api: https://github.com/codeready-toolchain/api/pull/423
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1030
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/970
