### PR TITLE
add caBundle to support backward compatibility

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -120,6 +120,7 @@ echo "SA token retrieved"
 if [[ ${LETS_ENCRYPT} == "true" ]]; then
     echo "Using let's encrypt certificate"
 else
+    SA_CA_CRT=$(oc config view --raw -o json ${OC_ADDITIONAL_PARAMS} | jq ".clusters[] | select(.name==\"$(oc config view -o json ${OC_ADDITIONAL_PARAMS} | jq ".contexts[] | select(.name==\"$(oc config current-context ${OC_ADDITIONAL_PARAMS} 2>/dev/null)\")" | jq -r .context.cluster)\")" | jq -r '.cluster."certificate-authority-data"')
     INSECURE_PARAM="  disabledTLSValidations:
     - '*'"
 fi
@@ -198,6 +199,7 @@ metadata:
     ${CLUSTER_LABEL}
 spec:
   apiEndpoint: ${API_ENDPOINT}
+  caBundle: ${SA_CA_CRT}
   secretRef:
     name: ${SECRET_NAME}
 ${INSECURE_PARAM}


### PR DESCRIPTION
Just after merging the previous PR I realized that this will break e2e tests in Konflux until I merge all other PRs (in e2e, host and member)
let's add the cert for now and remove it as soon as the PRs are merged