### PR TITLE
use 7 chars as short SHA

### DIFF
--- a/scripts/cd/olm-setup.sh
+++ b/scripts/cd/olm-setup.sh
@@ -277,8 +277,8 @@ replace_with_sed() {
 # it takes one boolean parameter - if the other repo (either embedded or main one) should be cloned or not
 setup_version_variables_based_on_commits() {
     # setup version and commit variables for the current repo
-    GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short HEAD`
-    PREVIOUS_GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short HEAD^`
+    GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short=7 HEAD`
+    PREVIOUS_GIT_COMMIT_ID=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-parse --short=7 HEAD^`
     NUMBER_OF_COMMITS=`git --git-dir=${PRJ_ROOT_DIR}/.git --work-tree=${PRJ_ROOT_DIR} rev-list --count HEAD`
 
     # check if there is main repo or inner repo specified
@@ -296,7 +296,7 @@ setup_version_variables_based_on_commits() {
 
 
         # and set version and comit variables also for this repo
-        OTHER_REPO_GIT_COMMIT_ID=`git --git-dir=${OTHER_REPO_PATH}/.git --work-tree=${OTHER_REPO_PATH} rev-parse --short HEAD`
+        OTHER_REPO_GIT_COMMIT_ID=`git --git-dir=${OTHER_REPO_PATH}/.git --work-tree=${OTHER_REPO_PATH} rev-parse --short=7 HEAD`
         OTHER_REPO_NUMBER_OF_COMMITS=`git --git-dir=${OTHER_REPO_PATH}/.git --work-tree=${OTHER_REPO_PATH} rev-list --count HEAD`
 
         if [[ -n "${MAIN_REPO_URL}"  ]]; then


### PR DESCRIPTION
replacement for https://github.com/codeready-toolchain/toolchain-cicd/pull/124
It enforces the number of short SHA chars to be 7 for the operator bundles, we can keep the binary image tags as they are.