### PR TITLE
upgrade operator-sdk to 1.38

### DIFF
--- a/prepare-tools-action/action.yml
+++ b/prepare-tools-action/action.yml
@@ -4,12 +4,12 @@ inputs:
   operator-sdk-version:
     description: Version of operator-sdk binary
     required: false
-    default: v1.36.0
+    default: v1.38.0
   operator-registry:
     description: Version of operator registry
     required: false
-    # see https://github.com/operator-framework/operator-sdk/blob/v1.36.0/go.mod#L22
-    default: v1.39.0
+    # see https://github.com/operator-framework/operator-sdk/blob/v1.38.0/go.mod#L20
+    default: v1.42.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description
We already did the first phase of PRs to upgrade the dependencies for openshift 4.17. Now the second phase is to actually upgrade operator-sdk

Tool/Library | Current Version | Updates to Version
-- | -- | --
Operator SDK | 1.36 | 1.38
Operator registry | v1.39.0 | v1.42.0

Related PRs: 
- https://github.com/codeready-toolchain/host-operator/pull/1160
- https://github.com/codeready-toolchain/member-operator/pull/645

## Issue ticket number and link
[SANDBOX-808](https://issues.redhat.com/browse/SANDBOX-808)