### PR TITLE
SANDBOX-1121: add govulncheck-with-ignore-vulns

### DIFF
--- a/govulncheck-with-ignore-vulns/.govulncheck.yaml
+++ b/govulncheck-with-ignore-vulns/.govulncheck.yaml
@@ -1,0 +1,19 @@
+ignore:
+  # Kubernetes kube-apiserver Vulnerable to Race Condition in k8s.io/kubernetes
+  # More info: https://pkg.go.dev/vuln/GO-2025-3547
+  # Module: k8s.io/kubernetes
+  # Fixed in: N/A
+  - id: GO-2025-3547
+    expires: 2025-05-10
+  # Kubernetes GitRepo Volume Inadvertent Local Repository Access in k8s.io/kubernetes
+  # More info: https://pkg.go.dev/vuln/GO-2025-3521
+  # Module: k8s.io/kubernetes
+  # Fixed in: N/A
+  - id: GO-2025-3521
+    expires: 2025-05-10
+  # Request smuggling due to acceptance of invalid chunked data in net/http
+  # More info: https://pkg.go.dev/vuln/GO-2025-3563
+  # Standard library
+  # Fixed in: net/http/internal@go1.23.8
+  - id: GO-2025-3563
+    expires: 2025-05-10

--- a/govulncheck-with-ignore-vulns/action.yml
+++ b/govulncheck-with-ignore-vulns/action.yml
@@ -1,0 +1,12 @@
+name: 'govulncheck-with-ignore-vulns'
+description: 'Run govulncheck ignoring vulnerabilities from config file'
+runs:
+  using: "composite"
+  steps:
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      shell: bash
+
+    - name: Run govulncheck-with-ignore-vulns
+      run: bash ${{ github.action_path }}/govulncheck-with-ignore-vulns.sh -cfg ${{ github.action_path }}/.govulncheck.yaml
+      shell: bash

--- a/govulncheck-with-ignore-vulns/govulncheck-with-ignore-vulns.sh
+++ b/govulncheck-with-ignore-vulns/govulncheck-with-ignore-vulns.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+user_help () {
+    echo "Runs govulncheck ignoring vulnerabilities from config file"
+    echo "options:"
+    echo "-cfg, --config-file      Path to the configuration file"
+    echo "-h,   --help             To show this help text"
+    echo ""
+    exit 0
+}
+
+read_arguments() {
+    if [[ $# -lt 2 ]]
+    then
+        user_help
+    fi
+
+    while test $# -gt 0; do
+           case "$1" in
+                -h|--help)
+                    user_help
+                    ;;
+                -cfg|--config-file)
+                    shift
+                    CONFIG_FILE=$1
+                    shift
+                    ;;
+                *)
+                   echo "$1 is not a recognized flag!" >> /dev/stderr
+                   user_help
+                   exit -1
+                   ;;
+          esac
+    done
+}
+
+set -e -o pipefail
+
+read_arguments $@
+
+today=$(date -I)
+
+# load vulns to ignore from $CONFIG_FILE using yq
+ignoreVulns="$(yq -o=json eval '.ignore' "$CONFIG_FILE")"
+echo ignoreVulns: $ignoreVulns
+
+# run govulncheck
+echo running govulncheck...
+json="$(govulncheck -json ./...)"
+
+# extract vulns reported by govulncheck
+vulns="$(jq <<<"$json" -cs '
+	(
+		map(
+			.osv // empty
+			| { key: .id, value: . }
+		)
+		| from_entries
+	) as $meta
+
+	| (
+		map(.finding) 
+		| map(select((.trace[0].function // "") != ""))
+		| map({ key: .osv, value: .trace[0].version })
+		| from_entries
+	) as $found_versions
+
+	| map(
+		.finding
+		| select((.trace[0].function // "") != "")
+		| .osv
+	)
+	| unique
+	| map(
+		$meta[.] + { found_in_version: ($found_versions[.] // "N/A") }
+	)
+')"
+
+echo vulnerabilities reported by govulncheck $vulns
+
+# filtering the vulnerabilities to ignore
+filtered="$(jq <<<"$vulns" -c --arg today "$today" --arg ignoreVulns "$ignoreVulns" '
+  ($ignoreVulns | fromjson) as $ignore
+  | map(select(
+      .id as $id
+      | $ignore | map(select(.id == $id and .expires > $today)) | length == 0
+  ))
+')"
+
+echo vulnerabilities filtered $filtered
+
+results="$(jq <<<"$filtered" -r 'map(
+  "- \(.id) (\(.database_specific.url))\n\t\(.details | gsub("\n"; "\n\t"))\n\tPackage: \(
+    if .affected[0].package.name == "stdlib" then
+      .affected[0].ecosystem_specific.imports[0].path // "N/A"
+    else
+      .affected[0].package.name // "N/A"
+    end
+  )\n\tFound in: \(
+    if .affected[0].package.name == "stdlib" then
+      "go@" + ((.found_in_version // "N/A") | sub("^v"; ""))
+    else
+      .found_in_version // "N/A"
+    end
+  )\n\tFixed in: \(
+    if .affected[0].package.name == "stdlib" then
+      "go@" + (.affected[0].ranges[0].events | map(select(.fixed != null)) | .[0].fixed // "N/A")
+    else
+      .affected[0].ranges[0].events | map(select(.fixed != null)) | .[0].fixed // "N/A"
+    end
+  )"
+) | join("\n\n")')"
+
+
+if [ -z "$results" ]; then
+	printf 'No vulnerabilities found.\n'
+	exit 0
+else
+	printf 'Vulnerabilities found:\n'
+	printf '%s\n' "$results"
+	exit 1
+fi


### PR DESCRIPTION
## Description
Unfortunately, govulncheck does not have a feature for ignoring the vulns. There is a [feature request](https://github.com/golang/go/issues/59507) but we do not know when it will be addressed. To avoid govulncheck failing in PRs, we need to address a workaround to ignore the vulns that do not have any fix available or require a higher go version that we have.


## How to test it
Locally, in your repo, add this gh action to `.github/workflows`
```
name: govulncheck-with-ignore-vulns
on:
  pull_request:
    branches:
      - master

jobs:
  govulncheck-with-ignore-vulns:
    name: govulncheck-with-ignore-vulns
    runs-on: ubuntu-latest

    steps:
    - name: Checkout code
      uses: actions/checkout@v4

    - name: Install Go
      uses: actions/setup-go@v5
      with:
        go-version-file: go.mod

    - name: Run govulncheck with ignore vulns feature
      uses: rsoaresd/toolchain-cicd/govulncheck-with-ignore-vulns@add_govulncheck-with-ignore-vulns
```
Then run `act` ([install it](https://github.com/nektos/act) if you do not have it)

## Issue ticket number and link
[SANDBOX-1121](https://issues.redhat.com/browse/SANDBOX-1121)