### PR TITLE
SANDBOX-955: update operator-sdk

### DIFF
--- a/prepare-tools-action/action.yml
+++ b/prepare-tools-action/action.yml
@@ -4,12 +4,12 @@ inputs:
   operator-sdk-version:
     description: Version of operator-sdk binary
     required: false
-    default: v1.38.0
+    default: v1.39.2
   operator-registry:
     description: Version of operator registry
     required: false
-    # see https://github.com/operator-framework/operator-sdk/blob/v1.38.0/go.mod#L20
-    default: v1.42.0
+    # see https://github.com/operator-framework/operator-sdk/blob/v1.39.2/go.mod#L20
+    default: v1.49.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description
Tool/Library | Current Version | Updates to Version
-- | -- | --
Operator SDK | 1.38 | 1.39.2
Operator registry |v1.42.0 | v1.49.0

Related PRs: 
- https://github.com/codeready-toolchain/member-operator/pull/665
- https://github.com/codeready-toolchain/host-operator/pull/1170

## Issue ticket number and link
[SANDBOX-955](https://issues.redhat.com/browse/SANDBOX-955)