### PR TITLE
add workflows for publishing operators and publishing the Developer Sandbox UI for UI E2E testing

### DIFF
--- a/publish-operators-for-ui-e2e-tests/action.yml
+++ b/publish-operators-for-ui-e2e-tests/action.yml
@@ -1,0 +1,53 @@
+name: 'Publish Current Toolchain Operators (Host & Member) for UI e2e Tests'
+description: 'An action that publishes the current version of Toolchain Operators as single releases for UI e2e Tests'
+inputs:
+  quay-token:
+    description: Quay token
+    required: true
+  quay-namespace:
+    description: Quay namespace
+    required: false
+    default: codeready-toolchain
+  sha:
+    description: PR head sha
+    default: ${{ github.event.pull_request.head.sha }}
+    required: false
+  pr-number:
+    description: Number of the PR
+    default: ${{ github.event.pull_request.number }}
+    required: false
+  author:
+    description: Author of the PR
+    default: ${{ github.event.pull_request.head.user.login }}
+    required: false
+  gh-head-ref:
+    description: Branch name the PR was opened from
+    default: ${{ github.event.pull_request.head.ref }}
+    required: false
+runs:
+  using: "composite"
+  steps:
+  - name: Login to quay
+    shell: bash
+    run: |
+      set -e
+      export XDG_RUNTIME_DIR=/run/user/${UID}
+      mkdir -p ${XDG_RUNTIME_DIR}/containers || true
+      echo "{
+                    \"auths\": {
+                            \"quay.io\": {
+                                    \"auth\": \"${{ inputs.quay-token }}\"
+                            }
+                    }
+            }"> ${XDG_RUNTIME_DIR}/containers/auth.json
+
+      podman login --get-login quay.io
+
+  - name: Publish current bundle for UI e2e Tests
+    shell: bash
+    run: |
+      PROVIDED_REF=${{ inputs.gh-head-ref }}
+      if [[ -n ${PROVIDED_REF} ]]; then
+        GH_HEAD_REF_PARAM="GITHUB_HEAD_REF=${PROVIDED_REF}"
+      fi
+      make publish-current-bundles-for-e2e QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ inputs.sha }} PULL_NUMBER=${{ inputs.pr-number }} AUTHOR=${{ inputs.author }} ${GH_HEAD_REF_PARAM} ENVIRONMENT=ui-e2e-tests

--- a/publish-sandbox-ui-for-ui-e2e-tests/action.yml
+++ b/publish-sandbox-ui-for-ui-e2e-tests/action.yml
@@ -1,0 +1,53 @@
+name: 'Publish Current Developer Sandbox UI'
+description: 'An action that publishes the current version of Developer Sandbox UI'
+inputs:
+  quay-token:
+    description: Quay token
+    required: true
+  quay-namespace:
+    description: Quay namespace
+    required: false
+    default: codeready-toolchain
+  sha:
+    description: PR head sha
+    default: ${{ github.event.pull_request.head.sha }}
+    required: false
+  pr-number:
+    description: Number of the PR
+    default: ${{ github.event.pull_request.number }}
+    required: false
+  author:
+    description: Author of the PR
+    default: ${{ github.event.pull_request.head.user.login }}
+    required: false
+  gh-head-ref:
+    description: Branch name the PR was opened from
+    default: ${{ github.event.pull_request.head.ref }}
+    required: false
+runs:
+  using: "composite"
+  steps:
+  - name: Login to quay
+    shell: bash
+    run: |
+      set -e
+      export XDG_RUNTIME_DIR=/run/user/${UID}
+      mkdir -p ${XDG_RUNTIME_DIR}/containers || true
+      echo "{
+                    \"auths\": {
+                            \"quay.io\": {
+                                    \"auth\": \"${{ inputs.quay-token }}\"
+                            }
+                    }
+            }"> ${XDG_RUNTIME_DIR}/containers/auth.json
+
+      podman login --get-login quay.io
+
+  - name: Publish current Developer Sandbox UI
+    shell: bash
+    run: |
+      PROVIDED_REF=${{ inputs.gh-head-ref }}
+      if [[ -n ${PROVIDED_REF} ]]; then
+        GH_HEAD_REF_PARAM="GITHUB_HEAD_REF=${PROVIDED_REF}"
+      fi
+      make push-sandbox-plugin QUAY_NAMESPACE=${{ inputs.quay-namespace }} IMAGE_BUILDER=podman PULL_PULL_SHA=${{ inputs.sha }} PULL_NUMBER=${{ inputs.pr-number }} AUTHOR=${{ inputs.author }} GITHUB_BRANCH="${PROVIDED_REF}" ${GH_HEAD_REF_PARAM}


### PR DESCRIPTION
## Description
The UI E2E test environment is ready in the toolchain-e2e repository (check #1148). To integrate Developer Sandbox UI E2E tests into the toolchain-e2e CI pipeline, we need to implement the publish operators for UI E2E testing, since we need to have dedicated published operators for UI E2E testing because we need a different ToolchainConfig configuration because of the SSO: https://github.com/codeready-toolchain/toolchain-e2e/blob/master/deploy/host-operator/ui-e2e-tests/toolchainconfig.yaml. 

So, to not duplicate the current publish-operators-for-e2e-tests, we need to adapt it to also publish operators for UI E2E testing

## Related PRs
https://github.com/codeready-toolchain/toolchain-e2e/pull/1180
https://github.com/codeready-toolchain/toolchain-e2e/pull/1181

## Issue ticket number and link
[SANDBOX-1371](https://issues.redhat.com/browse/SANDBOX-1371)