### PR TITLE
SANDBOX-1357: update operator-sdk and operator-registry

### DIFF
--- a/prepare-tools-action/action.yml
+++ b/prepare-tools-action/action.yml
@@ -4,12 +4,12 @@ inputs:
   operator-sdk-version:
     description: Version of operator-sdk binary
     required: false
-    default: v1.39.2
+    default: v1.40.0
   operator-registry:
     description: Version of operator registry
     required: false
-    # see https://github.com/operator-framework/operator-sdk/blob/v1.39.2/go.mod#L20
-    default: v1.49.0
+    # see https://github.com/operator-framework/operator-sdk/blob/v1.40.0/go.mod#L20
+    default: v1.55.0
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description
Tool/Library | Current Version | Updates to Version
-- | -- | --
Operator SDK | 1.39.2 | 1.40.0
Operator registry | v1.49.0| v1.55.0

## Related PRs
- https://github.com/codeready-toolchain/api/pull/484
- https://github.com/codeready-toolchain/member-operator/pull/696
- https://github.com/codeready-toolchain/host-operator/pull/1196
- https://github.com/codeready-toolchain/registration-service/pull/547
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1193
- https://github.com/codeready-toolchain/toolchain-common/pull/491
- https://github.com/kubesaw/ksctl/pull/125

## Issue ticket number and link
[SANDBOX-1357](https://issues.redhat.com/browse/SANDBOX-1357)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default tool versions used by the action to operator-sdk v1.40.0 and operator-registry v1.55.0, so runs using defaults will pick up the newer toolchain.

* **Documentation**
  * Adjusted input description to reference the correct version source for operator-registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->