### PR TITLE
set minimal version of go to 1.22.0 and define the go toolchain 1.22.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.gitignore.io/api/vim,git,macos,linux,emacs,windows,eclipse,intellij+all,visualstudiocode
+
+# Built binaries
+**/bin/

--- a/govulncheck-action/go.mod
+++ b/govulncheck-action/go.mod
@@ -1,6 +1,8 @@
 module github.com/codeready-toolchain/toolchain-cicd/govulncheck-action
 
-go 1.22.12
+go 1.22.0
+
+toolchain go1.22.12
 
 require (
 	github.com/spf13/cobra v1.9.1


### PR DESCRIPTION
to fix this problem https://github.com/codeready-toolchain/api/actions/runs/17480731430/job/49650494411?pr=485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded ignore rules to cover bin directories across the project, preventing accidental commits of compiled artifacts and keeping diffs clean.
  * Standardized the Go toolchain configuration to 1.22.x to improve reproducibility and consistency across local environments and CI, ensuring the same compiler version is used without changing dependencies or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->