### PR TITLE
bump actions/setup-go from 5 to 6

### DIFF
--- a/govulncheck-action/action.yaml
+++ b/govulncheck-action/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v5.0.0
+    - uses: actions/setup-go@v6.0.0
       with:
         check-latest: false
         go-version-file: ${{ inputs.go-version-file }}

--- a/govulncheck-action/action.yaml
+++ b/govulncheck-action/action.yaml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-go@v6.0.0
+    - uses: actions/setup-go@v6
       with:
         check-latest: false
         go-version-file: ${{ inputs.go-version-file }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI configuration to use the latest Go setup action (v6.0.0) for the vulnerability check workflow. All existing parameters remain unchanged, and the pipeline behavior is consistent with previous runs. No user-facing functionality, interfaces, or workflows are affected. No action is required from users, and existing integrations continue to work as before. No documentation or feature updates are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->