### PR TITLE
govulncheck: enforce 2 spaces of indentation in exclusion file

### DIFF
--- a/govulncheck-action/internal/configuration/configuration.go
+++ b/govulncheck-action/internal/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"time"
@@ -58,9 +59,14 @@ func Save(path string, cfg Configuration) error {
 
 	mapping.Content = append(mapping.Content, keyNode, seqNode)
 
-	data, err := yaml.Marshal(doc)
-	if err != nil {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(doc); err != nil {
 		return fmt.Errorf("failed to marshal configuration: %w", err)
 	}
-	return os.WriteFile(path, data, 0600)
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("failed to marshal configuration: %w", err)
+	}
+	return os.WriteFile(path, buf.Bytes(), 0600)
 }

--- a/govulncheck-action/internal/configuration/configuration.go
+++ b/govulncheck-action/internal/configuration/configuration.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -29,8 +30,44 @@ func New(path string) (Configuration, error) {
 	if err != nil {
 		return c, err
 	}
-	err = yaml.Unmarshal(contents, &c)
-	return c, err
+	var doc yaml.Node
+	if err := yaml.Unmarshal(contents, &doc); err != nil {
+		return c, err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return c, nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return c, fmt.Errorf("expected mapping node, got %d", root.Kind)
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key := root.Content[i]
+		val := root.Content[i+1]
+		if key.Value != "ignored-vulnerabilities" || val.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, entry := range val.Content {
+			v := &Vulnerability{}
+			if err := entry.Decode(v); err != nil {
+				return c, err
+			}
+			if entry.HeadComment != "" {
+				v.Comment = stripCommentMarkers(entry.HeadComment)
+			}
+			c.IgnoredVulnerabilities = append(c.IgnoredVulnerabilities, v)
+		}
+	}
+	return c, nil
+}
+
+func stripCommentMarkers(comment string) string {
+	lines := strings.Split(comment, "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		lines[i] = strings.TrimPrefix(line, "# ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func Save(path string, cfg Configuration) error {

--- a/govulncheck-action/internal/configuration/configuration_test.go
+++ b/govulncheck-action/internal/configuration/configuration_test.go
@@ -131,6 +131,37 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Contains(t, string(raw), "Found in: pkg@v1.0.0")
 	})
 
+	t.Run("save with 2-space indentation", func(t *testing.T) {
+		// given
+		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")
+		require.NoError(t, err)
+		silenceUntil := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+		cfg := configuration.Configuration{
+			IgnoredVulnerabilities: []*configuration.Vulnerability{
+				{
+					ID:           "GO-2025-0001",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0001",
+					Comment:      "Some vulnerability\nFound in: pkg@v1.0.0",
+				},
+			},
+		}
+		// when
+		err = configuration.Save(tempFile.Name(), cfg)
+		// then
+		require.NoError(t, err)
+		raw, err := os.ReadFile(tempFile.Name())
+		require.NoError(t, err)
+		expected := `ignored-vulnerabilities:
+  # Some vulnerability
+  # Found in: pkg@v1.0.0
+  - id: GO-2025-0001
+    silence-until: 2025-06-15
+    info: https://pkg.go.dev/vuln/GO-2025-0001
+`
+		assert.Equal(t, expected, string(raw))
+	})
+
 	t.Run("save empty config", func(t *testing.T) {
 		// given
 		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")

--- a/govulncheck-action/internal/configuration/configuration_test.go
+++ b/govulncheck-action/internal/configuration/configuration_test.go
@@ -90,6 +90,47 @@ func TestNewConfiguration(t *testing.T) {
 		assert.Equal(t, "https://pkg.go.dev/vuln/GO-2025-3563", c.IgnoredVulnerabilities[2].Info)
 	})
 
+	t.Run("load preserves comments", func(t *testing.T) {
+		// given
+		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")
+		require.NoError(t, err)
+
+		content := `ignored-vulnerabilities:
+  # Kubernetes kube-apiserver Vulnerable to Race Condition
+  # Found in: k8s.io/kubernetes@v1.31.0
+  # Fixed in: N/A
+  - id: GO-2025-3547
+    silence-until: 2025-05-10
+    info: https://pkg.go.dev/vuln/GO-2025-3547
+  # Request smuggling due to acceptance of invalid chunked data
+  # Found in: net/http/internal@go1.22.12
+  # Fixed in: net/http/internal@go1.23.8
+  - id: GO-2025-3563
+    silence-until: 2025-05-10
+    info: https://pkg.go.dev/vuln/GO-2025-3563
+  - id: GO-2025-0099
+    silence-until: 2025-05-10
+    info: https://pkg.go.dev/vuln/GO-2025-0099`
+		_, err = tempFile.WriteString(content)
+		require.NoError(t, err)
+
+		// when
+		c, err := configuration.New(tempFile.Name())
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, c.IgnoredVulnerabilities, 3)
+		// first entry: comment preserved
+		assert.Equal(t, "GO-2025-3547", c.IgnoredVulnerabilities[0].ID)
+		assert.Equal(t, "Kubernetes kube-apiserver Vulnerable to Race Condition\nFound in: k8s.io/kubernetes@v1.31.0\nFixed in: N/A", c.IgnoredVulnerabilities[0].Comment)
+		// second entry: comment preserved
+		assert.Equal(t, "GO-2025-3563", c.IgnoredVulnerabilities[1].ID)
+		assert.Equal(t, "Request smuggling due to acceptance of invalid chunked data\nFound in: net/http/internal@go1.22.12\nFixed in: net/http/internal@go1.23.8", c.IgnoredVulnerabilities[1].Comment)
+		// third entry: no comment
+		assert.Equal(t, "GO-2025-0099", c.IgnoredVulnerabilities[2].ID)
+		assert.Empty(t, c.IgnoredVulnerabilities[2].Comment)
+	})
+
 	t.Run("save and reload", func(t *testing.T) {
 		// given
 		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")
@@ -160,6 +201,162 @@ func TestNewConfiguration(t *testing.T) {
     info: https://pkg.go.dev/vuln/GO-2025-0001
 `
 		assert.Equal(t, expected, string(raw))
+	})
+
+	t.Run("save preserves existing entries and comments when adding new entry", func(t *testing.T) {
+		// given
+		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")
+		require.NoError(t, err)
+		silenceUntil := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+		cfg := configuration.Configuration{
+			IgnoredVulnerabilities: []*configuration.Vulnerability{
+				{
+					ID:           "GO-2025-0001",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0001",
+					Comment:      "Existing vulnerability one\nModule: pkg1@v1.0.0\nFixed in: N/A",
+				},
+				{
+					ID:           "GO-2025-0002",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0002",
+					Comment:      "Existing vulnerability two\nModule: pkg2@v2.0.0\nFixed in: pkg2@v2.0.1",
+				},
+			},
+		}
+		// save initial config
+		err = configuration.Save(tempFile.Name(), cfg)
+		require.NoError(t, err)
+
+		// add a new entry
+		newSilenceUntil := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		cfg.IgnoredVulnerabilities = append(cfg.IgnoredVulnerabilities, &configuration.Vulnerability{
+			ID:           "GO-2025-0003",
+			SilenceUntil: newSilenceUntil,
+			Info:         "https://pkg.go.dev/vuln/GO-2025-0003",
+			Comment:      "New vulnerability three\nModule: pkg3@v3.0.0\nFixed in: pkg3@v3.0.1",
+		})
+
+		// when
+		err = configuration.Save(tempFile.Name(), cfg)
+
+		// then
+		require.NoError(t, err)
+		// verify all entries are reloaded correctly
+		loaded, err := configuration.New(tempFile.Name())
+		require.NoError(t, err)
+		require.Len(t, loaded.IgnoredVulnerabilities, 3)
+		assert.Equal(t, "GO-2025-0001", loaded.IgnoredVulnerabilities[0].ID)
+		assert.Equal(t, "2025-06-15", loaded.IgnoredVulnerabilities[0].SilenceUntil.Format("2006-01-02"))
+		assert.Equal(t, "https://pkg.go.dev/vuln/GO-2025-0001", loaded.IgnoredVulnerabilities[0].Info)
+		assert.Equal(t, "GO-2025-0002", loaded.IgnoredVulnerabilities[1].ID)
+		assert.Equal(t, "2025-06-15", loaded.IgnoredVulnerabilities[1].SilenceUntil.Format("2006-01-02"))
+		assert.Equal(t, "https://pkg.go.dev/vuln/GO-2025-0002", loaded.IgnoredVulnerabilities[1].Info)
+		assert.Equal(t, "GO-2025-0003", loaded.IgnoredVulnerabilities[2].ID)
+		assert.Equal(t, "2025-09-01", loaded.IgnoredVulnerabilities[2].SilenceUntil.Format("2006-01-02"))
+		assert.Equal(t, "https://pkg.go.dev/vuln/GO-2025-0003", loaded.IgnoredVulnerabilities[2].Info)
+		// verify all comments are preserved in the raw file
+		raw, err := os.ReadFile(tempFile.Name())
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), "# Existing vulnerability one")
+		assert.Contains(t, string(raw), "# Module: pkg1@v1.0.0")
+		assert.Contains(t, string(raw), "# Fixed in: N/A")
+		assert.Contains(t, string(raw), "# Existing vulnerability two")
+		assert.Contains(t, string(raw), "# Module: pkg2@v2.0.0")
+		assert.Contains(t, string(raw), "# Fixed in: pkg2@v2.0.1")
+		assert.Contains(t, string(raw), "# New vulnerability three")
+		assert.Contains(t, string(raw), "# Module: pkg3@v3.0.0")
+		assert.Contains(t, string(raw), "# Fixed in: pkg3@v3.0.1")
+	})
+
+	t.Run("save preserves comments after config update with new and outdated vulns", func(t *testing.T) {
+		// given an initial config with 3 entries
+		tempFile, err := os.CreateTemp("", "ignored-vuln-*.yaml")
+		require.NoError(t, err)
+		silenceUntil := time.Date(2025, 5, 10, 0, 0, 0, 0, time.UTC)
+		initial := configuration.Configuration{
+			IgnoredVulnerabilities: []*configuration.Vulnerability{
+				{
+					ID:           "GO-2025-0001",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0001",
+					Comment:      "Vuln one summary\nFound in: pkg1@v1.0.0\nFixed in: N/A",
+				},
+				{
+					ID:           "GO-2025-0002",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0002",
+					Comment:      "Vuln two summary\nFound in: pkg2@v2.0.0\nFixed in: pkg2@v2.1.0",
+				},
+				{
+					ID:           "GO-2025-0003",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0003",
+					Comment:      "Vuln three summary\nFound in: pkg3@v3.0.0\nFixed in: N/A",
+				},
+			},
+		}
+		err = configuration.Save(tempFile.Name(), initial)
+		require.NoError(t, err)
+
+		// simulate UpdateConfig result: keep 0001, remove 0002 (outdated), keep 0003 with updated comment, add 0004 (new)
+		newSilenceUntil := time.Date(2025, 9, 1, 0, 0, 0, 0, time.UTC)
+		updated := configuration.Configuration{
+			IgnoredVulnerabilities: []*configuration.Vulnerability{
+				{
+					ID:           "GO-2025-0001",
+					SilenceUntil: silenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0001",
+					Comment:      "Vuln one summary\nFound in: pkg1@v1.0.0\nFixed in: N/A",
+				},
+				{
+					ID:           "GO-2025-0003",
+					SilenceUntil: newSilenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0003",
+					Comment:      "Vuln three updated summary\nFound in: pkg3@v3.0.0\nFixed in: pkg3@v3.1.0",
+				},
+				{
+					ID:           "GO-2025-0004",
+					SilenceUntil: newSilenceUntil,
+					Info:         "https://pkg.go.dev/vuln/GO-2025-0004",
+					Comment:      "Brand new vuln four\nFound in: pkg4@v4.0.0\nFixed in: pkg4@v4.0.1",
+				},
+			},
+		}
+
+		// when
+		err = configuration.Save(tempFile.Name(), updated)
+
+		// then
+		require.NoError(t, err)
+		// verify entries reload correctly
+		loaded, err := configuration.New(tempFile.Name())
+		require.NoError(t, err)
+		require.Len(t, loaded.IgnoredVulnerabilities, 3)
+		assert.Equal(t, "GO-2025-0001", loaded.IgnoredVulnerabilities[0].ID)
+		assert.Equal(t, "2025-05-10", loaded.IgnoredVulnerabilities[0].SilenceUntil.Format("2006-01-02"))
+		assert.Equal(t, "GO-2025-0003", loaded.IgnoredVulnerabilities[1].ID)
+		assert.Equal(t, "2025-09-01", loaded.IgnoredVulnerabilities[1].SilenceUntil.Format("2006-01-02"))
+		assert.Equal(t, "GO-2025-0004", loaded.IgnoredVulnerabilities[2].ID)
+		assert.Equal(t, "2025-09-01", loaded.IgnoredVulnerabilities[2].SilenceUntil.Format("2006-01-02"))
+		// verify comments in raw file
+		raw, err := os.ReadFile(tempFile.Name())
+		require.NoError(t, err)
+		rawStr := string(raw)
+		// kept entry: original comment preserved
+		assert.Contains(t, rawStr, "# Vuln one summary")
+		assert.Contains(t, rawStr, "# Found in: pkg1@v1.0.0")
+		assert.Contains(t, rawStr, "# Fixed in: N/A")
+		// outdated entry removed
+		assert.NotContains(t, rawStr, "GO-2025-0002")
+		assert.NotContains(t, rawStr, "# Vuln two summary")
+		// kept entry with updated comment
+		assert.Contains(t, rawStr, "# Vuln three updated summary")
+		assert.Contains(t, rawStr, "# Fixed in: pkg3@v3.1.0")
+		// new entry with comment
+		assert.Contains(t, rawStr, "# Brand new vuln four")
+		assert.Contains(t, rawStr, "# Found in: pkg4@v4.0.0")
+		assert.Contains(t, rawStr, "# Fixed in: pkg4@v4.0.1")
 	})
 
 	t.Run("save empty config", func(t *testing.T) {


### PR DESCRIPTION
some repositories are configured with a YAML linter requiring 2 spaces of indentation

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file generation with consistent two-space YAML indentation.
  * Preserved multiline comments and vulnerability details during configuration saves.
  * Maintained secure file permissions when writing configuration files.
  * Improved handling of invalid or incomplete configuration files.
  * Preserved existing ignored vulnerabilities when updating configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->